### PR TITLE
Introduce problem like error handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"thop/dom/service"
+	"thop/problem"
 
 	"github.com/spf13/cobra"
 )
@@ -29,10 +30,13 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		switch err.(type) {
 
-		// Prepared structure for custom error handling
+		// Prepared structure for custom error handling, but it's not used yet
+		case problem.Problem:
+			fmt.Println("Error:", err)
+			os.Exit(1)
 
 		default:
-			fmt.Println(err)
+			fmt.Println("Uncaught error:", err.Error())
 			os.Exit(1)
 
 		}

--- a/problem/problem.go
+++ b/problem/problem.go
@@ -1,0 +1,20 @@
+package problem
+
+type Key string
+
+func (k Key) WithMsg(msg string) Problem {
+	return Problem{Key: k, Message: msg}
+}
+
+type Problem struct {
+	Key     Key
+	Message string
+}
+
+func (p Problem) Error() string {
+	return p.Message
+}
+
+func (p Problem) EqualKey(other error) bool {
+	return p.Key == other.(Problem).Key
+}

--- a/test/problem/problem_test.go
+++ b/test/problem/problem_test.go
@@ -1,0 +1,37 @@
+package problem_test
+
+import (
+	"testing"
+	"thop/problem"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WithMsg(t *testing.T) {
+	t.Run("creates error with message", func(t *testing.T) {
+		// given
+		const key problem.Key = "test"
+		const msg string = "test message"
+
+		// when
+		var err error = key.WithMsg(msg)
+
+		// then
+		assert.Equal(t, msg, err.Error())
+		assert.Equal(t, key, err.(problem.Problem).Key)
+	})
+}
+
+func Test_EqualKey(t *testing.T) {
+	t.Run("returns true if keys are equal", func(t *testing.T) {
+		// given
+		const key problem.Key = "test"
+
+		// when
+		var prob = key.WithMsg("test message")
+		var err error = key.WithMsg("different message")
+
+		// then
+		assert.True(t, prob.EqualKey(err))
+	})
+}


### PR DESCRIPTION
Introduces a new structure for custom error handling

can be used by defining keys as const values and then returned as errors with a function:

example:

```go
const (
  ErrNotFound problem.Key = "ENTITY_NOT_FOUND"
)

func foo(entity string) error {
  return ErrNotFound.WithMsg(entity)
}

```