### PR TITLE
Check tmux server before listing sessions

### DIFF
--- a/internal/multiplexer/tmux_multiplexer.go
+++ b/internal/multiplexer/tmux_multiplexer.go
@@ -53,6 +53,10 @@ func (m *TmuxMultiplexer) AttachProject(p project.Project) error {
 }
 
 func (m *TmuxMultiplexer) ListActiveSessions() ([]project.Project, error) {
+	if !m.Client.IsTmuxServerRunning() {
+		return []project.Project(nil), nil
+	}
+
 	sessionNames, err := m.Client.ListSessions()
 	if err != nil {
 		return nil, err

--- a/internal/multiplexer/tmux_multiplexer_client.go
+++ b/internal/multiplexer/tmux_multiplexer_client.go
@@ -21,6 +21,7 @@ type TmuxClient interface {
 	NewWindow(SessionName, template.Root, window.Name, window.Root) error
 	SendKeys(SessionName, window.Name, command.Command) error
 	ListSessions() ([]SessionName, error)
+	IsTmuxServerRunning() bool
 }
 
 type TmuxClientImpl struct {
@@ -38,6 +39,12 @@ const (
 	ErrTriedToBuildFromActiveSession problem.Key = "TMUX_TRIED_TO_BUILD_FROM_ACTIVE_SESSION"
 	ErrInvalidTemplateArgs           problem.Key = "TMUX_INVALID_TEMPLATE_ARGS"
 )
+
+func (c *TmuxClientImpl) IsTmuxServerRunning() bool {
+	cmd := exec.Command("tmux", "run")
+	_, _, err := c.E.Execute(cmd)
+	return err == nil
+}
 
 func (c *TmuxClientImpl) AttachSession(session SessionName) error {
 	if session == "" {

--- a/test/multiplexer/tmux_multiplexer_client_test.go
+++ b/test/multiplexer/tmux_multiplexer_client_test.go
@@ -438,3 +438,41 @@ func Test_Client_ListSessions(t *testing.T) {
 		executor.AssertExpectations(t)
 	})
 }
+
+func Test_IsTmuxServerRunning(t *testing.T) {
+	t.Run("returns true if tmux server is running", func(t *testing.T) {
+		// given
+		executor := new(MockCommandExecutor)
+		executor.On("Execute", mock.Anything).Return("tmux", 0, nil).Once()
+
+		client := multiplexer.TmuxClientImpl{
+			E: executor,
+		}
+
+		// when
+		running := client.IsTmuxServerRunning()
+
+		// then
+		assert.True(t, running)
+		assert.Equal(t, executor.ExecutedCommands, [][]string{{"tmux", "run"}})
+		executor.AssertExpectations(t)
+	})
+
+	t.Run("returns false if tmux server is not running", func(t *testing.T) {
+		// given
+		executor := new(MockCommandExecutor)
+		executor.On("Execute", mock.Anything).Return("tmux", 1, errors.New("exit code 1")).Once()
+
+		client := multiplexer.TmuxClientImpl{
+			E: executor,
+		}
+
+		// when
+		running := client.IsTmuxServerRunning()
+
+		// then
+		assert.False(t, running)
+		assert.Equal(t, executor.ExecutedCommands, [][]string{{"tmux", "run"}})
+		executor.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
When running open command due to new listing of active sessions the process would crash if tmux server was not running, this fixes it