### PR TITLE
Introduce Kill Command & Open command can also "find" active sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ create [name]          Creates a session template.
 delete [name]          Deletes a session template.
 edit [name]            Edits a session template.
 help                   Shows help message.
+kill [name]            Kills a session.
 open [name]            Opens a session template.
 ```
 
-`[name]` argument is always optional, if not provided thop will use defaults and sometimes launch a project selector powered by fzf
+`[name]` argument is always optional, if not provided thop will use defaults and (when needed) launch selector powered by fzf
 
 ### Editor
 
@@ -59,6 +60,7 @@ You can use aliases to make your life easier:
 thop create:            thop c, thop new, thop add, thop a
 thop delete:            thop d
 thop edit:              thop e
+thop kill:              thop k,
 thop open:              thop o, thop select, thop s, thop
 ```
 
@@ -95,5 +97,4 @@ This project is in a somewhat early experimental stage, it's destination is set 
 ### Ideas:
 - A general config file
 - Video showcase in README
-- Kill command to kill active tmux session
 - Create more defaults (windows, panes), to be more independent from the "correct" template

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"thop/internal/types/project"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(killCmd)
+}
+
+var killCmd = &cobra.Command{
+	Use:     "kill [session]",
+	Short:   "Kill active tmux session",
+	Aliases: []string{"k"},
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var projectName string
+		if len(args) == 0 {
+			projectName = ""
+		} else {
+			projectName = args[0]
+		}
+
+		return AppService.KillProject(project.Name(projectName))
+	},
+}

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -23,6 +23,6 @@ var killCmd = &cobra.Command{
 			projectName = args[0]
 		}
 
-		return AppService.KillProject(project.Name(projectName))
+		return AppService.KillSession(project.Name(projectName))
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,12 +32,15 @@ func Execute() {
 		switch err.(type) {
 
 		case problem.Problem:
+			// special case for selector cancellation
 			if selector.ErrSelectorCancelled.Equal(err) {
 				fmt.Println("Selection cancelled")
 				os.Exit(0)
 			}
 
-			fmt.Println("Error:", err)
+			problem := err.(problem.Problem)
+
+			fmt.Println(problem.Key + ":", problem.Message)
 			os.Exit(1)
 
 		default:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func Execute() {
 
 			problem := err.(problem.Problem)
 
-			fmt.Println(problem.Key + ":", problem.Message)
+			fmt.Println(problem.Key+":", problem.Message)
 			os.Exit(1)
 
 		default:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		switch err.(type) {
+		switch err := err.(type) {
 
 		case problem.Problem:
 			// special case for selector cancellation
@@ -38,9 +38,7 @@ func Execute() {
 				os.Exit(0)
 			}
 
-			problem := err.(problem.Problem)
-
-			fmt.Println(problem.Key+":", problem.Message)
+			fmt.Println(err.Key+":", err.Message)
 			os.Exit(1)
 
 		default:

--- a/internal/multiplexer/tmux_multiplexer.go
+++ b/internal/multiplexer/tmux_multiplexer.go
@@ -8,6 +8,7 @@ import (
 type Multiplexer interface {
 	AttachProject(project.Project) error
 	ListActiveSessions() ([]project.Project, error)
+	KillSession(project.Project) error
 }
 
 type TmuxMultiplexer struct {
@@ -68,6 +69,19 @@ func (m *TmuxMultiplexer) ListActiveSessions() ([]project.Project, error) {
 	}
 
 	return tmuxProjects, nil
+}
+
+func (m *TmuxMultiplexer) KillSession(p project.Project) error {
+	sessionName, err := resolveSessionName(p)
+	if err != nil {
+		return err
+	}
+
+	if err := m.Client.KillSession(sessionName); err != nil {
+		return err
+	}
+	
+	return nil
 }
 
 func (m *TmuxMultiplexer) assembleSession(sessionName SessionName, p project.Project) error {

--- a/internal/multiplexer/tmux_multiplexer.go
+++ b/internal/multiplexer/tmux_multiplexer.go
@@ -80,7 +80,7 @@ func (m *TmuxMultiplexer) KillSession(p project.Project) error {
 	if err := m.Client.KillSession(sessionName); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/internal/problem/problem.go
+++ b/internal/problem/problem.go
@@ -23,9 +23,9 @@ func (k Key) Equal(other error) bool {
 		return false
 	}
 
-	switch other.(type) {
+	switch other := other.(type) {
 	case Problem:
-		return k == other.(Problem).Key
+		return k == other.Key
 	default:
 		return false
 	}

--- a/internal/problem/problem.go
+++ b/internal/problem/problem.go
@@ -22,5 +22,11 @@ func (k Key) Equal(other error) bool {
 	if other == nil {
 		return false
 	}
-	return k == other.(Problem).Key
+
+	switch other.(type) {
+	case Problem:
+		return k == other.(Problem).Key
+	default:
+		return false
+	}
 }

--- a/internal/service/app_service.go
+++ b/internal/service/app_service.go
@@ -19,6 +19,7 @@ type Service interface {
 	OpenProject(project.Name) error
 	DeleteProject(project.Name) error
 	EditProject(project.Name) error
+	KillSession(project.Name) error
 }
 
 type AppService struct {
@@ -30,10 +31,12 @@ type AppService struct {
 }
 
 const (
-	ErrEditorNotSet        problem.Key = "THOP_EDITOR_NOT_SET"
-	ErrEmptyProjectName    problem.Key = "THOP_EMPTY_PROJECT_NAME"
-	ErrEmptyRootPath       problem.Key = "THOP_EMPTY_ROOT_PATH"
-	ErrSelectedNonExisting problem.Key = "THOP_SELECTED_NON_EXISTING"
+	ErrEditorNotSet             problem.Key = "THOP_EDITOR_NOT_SET"
+	ErrEmptyProjectName         problem.Key = "THOP_EMPTY_PROJECT_NAME"
+	ErrEmptyRootPath            problem.Key = "THOP_EMPTY_ROOT_PATH"
+	ErrSelectedNonExisting      problem.Key = "THOP_SELECTED_NON_EXISTING"
+	ErrSessionNotFound          problem.Key = "THOP_SESSION_NOT_FOUND"
+	ErrProjectOrSessionNotFound problem.Key = "THOP_PROJECT_OR_SESSION_NOT_FOUND"
 )
 
 const (
@@ -64,16 +67,54 @@ func (s *AppService) CreateProject(root template.Root, name project.Name) error 
 }
 
 func (s *AppService) OpenProject(name project.Name) error {
-	p, err := s.findOrSelect(name, "Select project to open > ", true)
+	if name != "" {
+		p, err := s.Storage.Find(name)
+
+		if err == nil {
+			return s.Multiplexer.AttachProject(p)
+		}
+
+		if !storage.ErrProjectNotFound.Equal(err) {
+			return err
+		}
+
+		// try to find active session if no template is found
+		active, err := s.Multiplexer.ListActiveSessions()
+		if err != nil {
+			return err
+		}
+
+		for _, session := range active {
+			if session.Name == name {
+				return s.Multiplexer.AttachProject(session)
+			}
+		}
+
+		return ErrProjectOrSessionNotFound.WithMsg(name)
+	}
+
+	projects, err := s.Storage.List()
 	if err != nil {
 		return err
 	}
 
-	return s.Multiplexer.AttachProject(p)
+	sessions, err := s.Multiplexer.ListActiveSessions()
+	if err != nil {
+		return err
+	}
+
+	projects = append(projects, sessions...)
+
+	found, err := s.Selector.SelectFrom(projects, "Select project to open > ")
+	if err != nil {
+		return err
+	}
+
+	return s.Multiplexer.AttachProject(*found)
 }
 
 func (s *AppService) DeleteProject(name project.Name) error {
-	p, err := s.findOrSelect(name, "Select project to delete > ", false)
+	p, err := s.findOrSelect(name, "Select project to delete > ")
 	if err != nil {
 		return err
 	}
@@ -82,7 +123,7 @@ func (s *AppService) DeleteProject(name project.Name) error {
 }
 
 func (s *AppService) EditProject(name project.Name) error {
-	p, err := s.findOrSelect(name, "Select project to edit > ", false)
+	p, err := s.findOrSelect(name, "Select project to edit > ")
 	if err != nil {
 		return err
 	}
@@ -102,44 +143,38 @@ func (s *AppService) EditProject(name project.Name) error {
 	return err
 }
 
-func (s *AppService) findOrSelect(name project.Name, prompt string, withActiveSessions bool) (project.Project, error) {
+func (s *AppService) KillSession(name project.Name) error {
+	sessions, err := s.Multiplexer.ListActiveSessions()
+	if err != nil {
+		return err
+	}
+
 	if name != "" {
-		p, err := s.Storage.Find(name)
-		if err != nil {
-			// if we can't find project, if enabled we can try to fallback to active session
-			if withActiveSessions {
-				if !storage.ErrProjectNotFound.Equal(err) {
-					return project.Project{}, err
-				}
-
-				sessions, err := s.Multiplexer.ListActiveSessions()
-				if err != nil {
-					return project.Project{}, err
-				}
-
-				for _, session := range sessions {
-					if session.Name == name {
-						return session, nil
-					}
-				}
-			} else {
-				return p, err
+		for _, session := range sessions {
+			if session.Name == name {
+				return s.Multiplexer.KillSession(session)
 			}
 		}
-		return p, nil
+		return ErrSessionNotFound.WithMsg(name)
+	}
+
+	selected, err := s.Selector.SelectFrom(sessions, "Select session to kill > ")
+	if err != nil {
+		return err
+	}
+
+	return s.Multiplexer.KillSession(*selected)
+}
+
+// common logic used by most commands
+func (s *AppService) findOrSelect(name project.Name, prompt string) (project.Project, error) {
+	if name != "" {
+		return s.Storage.Find(name)
 	}
 
 	projects, err := s.Storage.List()
 	if err != nil {
 		return project.Project{}, err
-	}
-
-	if withActiveSessions {
-		sessions, err := s.Multiplexer.ListActiveSessions()
-		if err != nil {
-			return project.Project{}, err
-		}
-		projects = append(projects, sessions...)
 	}
 
 	selected, err := s.Selector.SelectFrom(projects, prompt)

--- a/test/multiplexer/tmux_multiplexer_client_test.go
+++ b/test/multiplexer/tmux_multiplexer_client_test.go
@@ -476,3 +476,38 @@ func Test_IsTmuxServerRunning(t *testing.T) {
 		executor.AssertExpectations(t)
 	})
 }
+
+func Test_KillSession(t *testing.T) {
+	t.Run("returns error if session name is empty", func(t *testing.T) {
+		// given
+		client := multiplexer.TmuxClientImpl{
+			E: nil,
+		}
+
+		// when
+		err := client.KillSession("")
+
+		// then
+		assert.True(t, multiplexer.ErrInvalidTemplateArgs.Equal(err))
+	})
+
+	t.Run("kills session", func(t *testing.T) {
+		// given
+		executor := new(MockCommandExecutor)
+		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		expectedCmd := [][]string{
+			{"tmux", "kill-session", "-t", "mysession"},
+		}
+
+		client := multiplexer.TmuxClientImpl{
+			E: executor,
+		}
+
+		// when
+		err := client.KillSession("mysession")
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
+	})
+}

--- a/test/multiplexer/tmux_mutliplexer_test.go
+++ b/test/multiplexer/tmux_mutliplexer_test.go
@@ -70,6 +70,11 @@ func (m *MockTmuxClient) IsTmuxServerRunning() bool {
 	return args.Bool(0)
 }
 
+func (m *MockTmuxClient) KillSession(session multiplexer.SessionName) error {
+	args := m.Called(session)
+	return args.Error(0)
+}
+
 func Test_AttachProject(t *testing.T) {
 	t.Run("assembles and attaches to session if it doesn't exist", func(t *testing.T) {
 		// given

--- a/test/problem/problem_test.go
+++ b/test/problem/problem_test.go
@@ -1,6 +1,7 @@
 package problem_test
 
 import (
+	"errors"
 	"testing"
 	"thop/internal/problem"
 
@@ -32,5 +33,16 @@ func Test_Equal(t *testing.T) {
 
 		// then
 		assert.True(t, key.Equal(err))
+	})
+
+	t.Run("returns false if error is not a problem", func(t *testing.T) {
+		// given
+		const key problem.Key = "test"
+
+		// when
+		var err error = errors.New("some error")
+
+		// then
+		assert.False(t, key.Equal(err))
 	})
 }

--- a/test/problem/problem_test.go
+++ b/test/problem/problem_test.go
@@ -40,7 +40,7 @@ func Test_Equal(t *testing.T) {
 		const key problem.Key = "test"
 
 		// when
-		var err error = errors.New("some error")
+		var err = errors.New("some error")
 
 		// then
 		assert.False(t, key.Equal(err))

--- a/test/service/app_service_test.go
+++ b/test/service/app_service_test.go
@@ -7,6 +7,7 @@ import (
 	"thop/internal/config"
 	"thop/internal/problem"
 	"thop/internal/service"
+	"thop/internal/storage"
 	"thop/internal/types/project"
 	"thop/internal/types/template"
 	"thop/internal/types/window"
@@ -236,6 +237,41 @@ func Test_OpenProject(t *testing.T) {
 		assert.Equal(t, expected, err)
 		slMock.AssertExpectations(t)
 		stMock.AssertExpectations(t)
+	})
+
+	t.Run("finds active session and opens it", func(t *testing.T) {
+		// given
+		projects := []project.Project{
+			{UUID: "1234", Name: "foobar"},
+		}
+		sessions := []project.Project{
+			{Name: "foobar", Type: project.TypeTmuxSession},
+			{Name: "barfoo", Type: project.TypeTmuxSession},
+		}
+		combined := append(projects, sessions...)
+
+		stMock := new(test.MockStorage)
+		errNotFound := storage.ErrProjectNotFound.WithMsg("project", "foobar", "not found")
+		stMock.On("Find", project.Name("foobar")).Return(project.Project{}, errNotFound).Once()
+
+		muMock := new(test.MockMultiplexer)
+		muMock.On("AttachProject", combined[1]).Return(nil).Once()
+		muMock.On("ListActiveSessions").Return(sessions, nil).Once()
+
+		svc := &service.AppService{
+			Selector:    nil,
+			Multiplexer: muMock,
+			Storage:     stMock,
+			E:           nil,
+		}
+
+		// when
+		err := svc.OpenProject("foobar")
+
+		// then
+		assert.Nil(t, err)
+		stMock.AssertExpectations(t)
+		muMock.AssertExpectations(t)
 	})
 }
 

--- a/test/service/app_service_test.go
+++ b/test/service/app_service_test.go
@@ -560,7 +560,6 @@ func Test_KillSession(t *testing.T) {
 		// given
 		projects := []project.Project{{UUID: "1234", Name: "foobar", Type: project.TypeTmuxSession}}
 
-
 		slMock := new(test.MockProjectSelector)
 		slMock.On("SelectFrom", projects, mock.Anything).Return(&projects[0], nil).Once()
 

--- a/test/type_mocks.go
+++ b/test/type_mocks.go
@@ -36,6 +36,11 @@ func (m *MockMultiplexer) ListActiveSessions() ([]project.Project, error) {
 	return args.Get(0).([]project.Project), args.Error(1)
 }
 
+func (m *MockMultiplexer) KillSession(p project.Project) error {
+	args := m.Called(p)
+	return args.Error(0)
+}
+
 type MockStorage struct {
 	mock.Mock
 }
@@ -85,6 +90,11 @@ func (m *MockService) DeleteProject(name project.Name) error {
 }
 
 func (m *MockService) EditProject(name project.Name) error {
+	args := m.Called(name)
+	return args.Error(0)
+}
+
+func (m *MockService) KillSession(name project.Name) error {
 	args := m.Called(name)
 	return args.Error(0)
 }


### PR DESCRIPTION
This pr introduces:

1. Kill command that serves as a wrapper for tmux to kill active tmux session (implemented in similar fashion as all the other commands)
2. Searching through active sessions when trying to "find" a template via name arg in open command