### PR TITLE
Kill the session if assembling fails

### DIFF
--- a/internal/multiplexer/tmux_multiplexer.go
+++ b/internal/multiplexer/tmux_multiplexer.go
@@ -106,6 +106,13 @@ func (m *TmuxMultiplexer) assembleSession(sessionName SessionName, pro project.P
 		return err
 	}
 
+	// from this point on, if any error occurs, kill the session
+	defer func() {
+		if err != nil {
+			m.Client.KillSession(sessionName)
+		}
+	}()
+
 	for i, window := range pro.Template.Windows {
 		// first window is created together with the session, so skip it
 		if i != 0 {

--- a/test/multiplexer/tmux_multiplexer_test.go
+++ b/test/multiplexer/tmux_multiplexer_test.go
@@ -1,6 +1,7 @@
 package multiplexer_test
 
 import (
+	"errors"
 	"testing"
 	"thop/internal/multiplexer"
 	"thop/internal/types/command"
@@ -154,6 +155,47 @@ func Test_AttachProject(t *testing.T) {
 
 		// then
 		assert.Nil(t, err, "Expected no error")
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("kills the session if assembling fails after session is created", func(t *testing.T) {
+		// given
+		sessionName := multiplexer.SessionName("foo")
+		root := template.Root("/home/test")
+		window1Name := window.Name("main")
+		project := project.Project{
+			UUID: "uuid",
+			Name: "foo",
+			Template: template.Template{
+				Root:     root,
+				Commands: []command.Command{"echo hello"},
+				Windows: []window.Window{
+					{
+						Name:   window1Name,
+						Root:   "/project",
+						Panes:  []pane.Pane{{}},
+						Layout: window.LayoutTiled,
+					},
+				},
+			},
+		}
+
+		mockClient := new(MockTmuxClient)
+		mockClient.On("HasSession", sessionName).Return(false, nil).Once()
+		mockClient.On("NewSession", sessionName, root, project.Template.Windows[0]).Return(nil).Once()
+		expectedErr := errors.New("some error")
+		mockClient.On("ListPanes", sessionName, window1Name).Return([]multiplexer.PaneID(nil), expectedErr).Once()
+		mockClient.On("KillSession", sessionName).Return(nil).Once()
+
+		multiplexer := multiplexer.TmuxMultiplexer{
+			Client: mockClient,
+		}
+
+		// when
+		err := multiplexer.AttachProject(project)
+
+		// then
+		assert.Equal(t, expectedErr, err)
 		mockClient.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
This PR introduces killing of the session if assembling of it fails.

This eliminates the problem of half-assembled session hanging in tmux