### PR TITLE
Multiplexer & Validation logic improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ template:
     panes:                                  # List of panes to be created
     - run:
       - nvim                                # List of commands to be executed in this pane
-    - root: /optional/root/dir/pane         # Root directory for this pane (doesn't work for 1st pane)
+    - root: /optional/root/dir/pane         # Root directory for this pane
       active: true                          # Set as active pane
   - name: logs
     active: true                            # Set as active window

--- a/internal/executor/shell_executor.go
+++ b/internal/executor/shell_executor.go
@@ -13,6 +13,7 @@ type CommandExecutor interface {
 type ShellExecutor struct{}
 
 func (s *ShellExecutor) Execute(cmd *exec.Cmd) (string, int, error) {
+	println(cmd.String())
 	res, err := cmd.Output()
 	return string(res), cmd.ProcessState.ExitCode(), err
 }

--- a/internal/multiplexer/tmux_multiplexer.go
+++ b/internal/multiplexer/tmux_multiplexer.go
@@ -3,7 +3,9 @@ package multiplexer
 import (
 	"fmt"
 	"slices"
+	"thop/internal/types/pane"
 	"thop/internal/types/project"
+	"thop/internal/types/window"
 )
 
 type Multiplexer interface {
@@ -17,40 +19,31 @@ type TmuxMultiplexer struct {
 	Client            TmuxClient
 }
 
-type SessionName string
-
 func (m *TmuxMultiplexer) AttachProject(p project.Project) error {
-	sessionName, err := resolveSessionName(p)
+	sn := resolveSessionName(p)
+	exists, err := m.Client.HasSession(sn)
 	if err != nil {
 		return err
 	}
 
-	sessionExists, err := m.Client.HasSession(sessionName)
-	if err != nil {
-		return err
-	}
-
-	if !sessionExists {
+	if !exists {
 		if p.Type == project.TypeTmuxSession {
 			return ErrTriedToBuildFromActiveSession.WithMsg("cannot build from active session (it was probably killed while thop was running)")
 		}
 
-		// set default values for missing fields if needed
-		p.Template = p.Template.WithDefaults()
-
-		if err := m.assembleSession(sessionName, p); err != nil {
+		if err := m.assembleSession(sn, p); err != nil {
 			return err
 		}
 	}
 
 	if m.ActiveTmuxSession != "" {
-		fmt.Println("Switching to", sessionName, "session")
-		if err := m.Client.SwitchSession(sessionName); err != nil {
+		fmt.Println("Switching to", sn, "session")
+		if err := m.Client.SwitchSession(sn); err != nil {
 			return err
 		}
 	} else {
-		fmt.Println("Attaching to", sessionName, "session")
-		if err := m.Client.AttachSession(sessionName); err != nil {
+		fmt.Println("Attaching to", sn, "session")
+		if err := m.Client.AttachSession(sn); err != nil {
 			return err
 		}
 	}
@@ -60,7 +53,7 @@ func (m *TmuxMultiplexer) AttachProject(p project.Project) error {
 
 func (m *TmuxMultiplexer) ListActiveSessions() ([]project.Project, error) {
 	if !m.Client.IsTmuxServerRunning() {
-		return []project.Project(nil), nil
+		return nil, nil
 	}
 
 	sessionNames, err := m.Client.ListSessions()
@@ -70,109 +63,95 @@ func (m *TmuxMultiplexer) ListActiveSessions() ([]project.Project, error) {
 
 	var tmuxProjects []project.Project
 	for _, sessionName := range sessionNames {
-		tmuxProjects = append(tmuxProjects, project.Project{Name: project.Name(sessionName), Type: project.TypeTmuxSession})
+		// simple project with only name and type signaling its not regular template
+		p := project.Project{
+			Name: project.Name(sessionName),
+			Type: project.TypeTmuxSession,
+		}
+
+		tmuxProjects = append(tmuxProjects, p)
 	}
 
 	return tmuxProjects, nil
 }
 
 func (m *TmuxMultiplexer) KillSession(p project.Project) error {
-	sessionName, err := resolveSessionName(p)
+	sn := resolveSessionName(p)
+	return m.Client.KillSession(sn)
+}
+
+func (m *TmuxMultiplexer) assembleSession(sn SessionName, p project.Project) (err error) {
+	windows := map[WindowID]window.Window{}
+	windowIdsToPaneIds := map[WindowID][]PaneID{}
+	panes := map[PaneID]pane.Pane{}
+
+	// first window gets created together with the session
+	wID, pID, err := m.Client.NewSession(sn, p.Template)
 	if err != nil {
 		return err
 	}
 
-	if err := m.Client.KillSession(sessionName); err != nil {
-		return err
-	}
+	// save main window and main pane
+	windows[wID] = p.Template.Windows[0]
+	panes[pID] = p.Template.Windows[0].Panes[0]
+	windowIdsToPaneIds[wID] = []PaneID{pID}
 
-	return nil
-}
-
-func (m *TmuxMultiplexer) assembleSession(sessionName SessionName, pro project.Project) (err error) {
-	sessionRoot := pro.Template.Root
-	if sessionRoot == "" {
-		return ErrInvalidTemplateArgs.WithMsg("session root cannot be empty")
-	}
-
-	if len(pro.Template.Windows) == 0 {
-		return ErrInvalidTemplateArgs.WithMsg("project template needs at least one window to be created")
-	}
-
-	mainWindow := pro.Template.Windows[0]
-
-	// first window gets created together with the session
-	if err = m.Client.NewSession(sessionName, sessionRoot, mainWindow); err != nil {
-		return err
-	}
-
-	// from this point on, if any error occurs, kill the session
+	// from this point on, if any error occurs, attempt to kill the session
 	defer func() {
 		if err != nil {
-			m.Client.KillSession(sessionName)
+			m.Client.KillSession(sn)
 		}
 	}()
 
-	for i, window := range pro.Template.Windows {
-		// first window is created together with the session, so skip it
-		if i != 0 {
-			if err = m.Client.NewWindow(sessionName, sessionRoot, window); err != nil {
-				return err
-			}
-		}
+	t := p.Template
 
-		// first pane is created together with the window, so skip it
-		for _, p := range window.Panes[1:] {
-
-			var fallbackRoot string
-			if window.Root != "" {
-				fallbackRoot = string(window.Root)
-			} else {
-				fallbackRoot = string(sessionRoot)
-			}
-
-			if err = m.Client.NewPane(sessionName, window.Name, p, fallbackRoot); err != nil {
-				return err
-			}
-
-			// set layout after each pane to ensure, layout is up to its limits
-			if err = m.Client.SetLayout(sessionName, window); err != nil {
-				return err
-			}
-		}
-
-		paneIDs, err := m.Client.ListPanes(sessionName, window.Name)
+	// initialize additional windows
+	// first window is created together with the session, so skip it
+	for _, w := range t.Windows[1:] {
+		wID, pID, err := m.Client.NewWindow(sn, t.Root, w)
 		if err != nil {
 			return err
 		}
 
-		for paneIndex, paneID := range paneIDs {
-			if len(paneIDs) != len(window.Panes) {
-				panic(fmt.Errorf("invalid state: panes count does not match window panes count"))
+		windows[wID] = w
+		// save main pane of the window
+		panes[pID] = w.Panes[0]
+		windowIdsToPaneIds[wID] = []PaneID{pID}
+	}
+
+	// initialize additional panes
+	for wID, w := range windows {
+		// first pane is created together with the window, so skip it
+		for _, p := range w.Panes[1:] {
+			pID, err := m.Client.NewPane(wID, t.Root, w.Root, p)
+			if err != nil {
+				return err
 			}
 
-			commands := slices.Concat(pro.Template.Commands, window.Commands, window.Panes[paneIndex].Commands)
+			panes[pID] = p
+			windowIdsToPaneIds[wID] = append(windowIdsToPaneIds[wID], pID)
 
-			for _, keys := range commands {
-				if err = m.Client.SendKeys(paneID, keys); err != nil {
+			// set layout after each pane to ensure, layout is up to its limits
+			if err = m.Client.SetLayout(wID, w.Layout); err != nil {
+				return err
+			}
+		}
+	}
+
+	// execute shell commands
+	for wID, pIDs := range windowIdsToPaneIds {
+		for _, pID := range pIDs {
+			w := windows[wID]
+			p := panes[pID]
+			cmds := slices.Concat(t.Commands, w.Commands, p.Commands)
+			for _, keys := range cmds {
+				if err = m.Client.SendKeys(pID, keys); err != nil {
 					return err
 				}
 			}
 		}
 	}
 
-	fmt.Println("Session", sessionName, "created")
+	fmt.Println("Session", sn, "created")
 	return nil
-}
-
-func resolveSessionName(p project.Project) (SessionName, error) {
-	if p.Template.Name != "" {
-		return SessionName(p.Template.Name), nil
-	}
-
-	if p.Name == "" {
-		return "", ErrInvalidTemplateArgs.WithMsg("project name cannot be empty")
-	}
-
-	return SessionName(p.Name), nil
 }

--- a/internal/multiplexer/tmux_multiplexer_client.go
+++ b/internal/multiplexer/tmux_multiplexer_client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"slices"
 	"strings"
 	"thop/internal/executor"
 	"thop/internal/problem"
@@ -14,20 +13,17 @@ import (
 	"thop/internal/types/window"
 )
 
-type PaneID string
-
 type TmuxClient interface {
 	AttachSession(SessionName) error
 	HasSession(SessionName) (bool, error)
 	IsTmuxServerRunning() bool
 	KillSession(SessionName) error
-	ListPanes(SessionName, window.Name) ([]PaneID, error)
 	ListSessions() ([]SessionName, error)
-	NewPane(SessionName, window.Name, pane.Pane, string) error
-	NewSession(SessionName, template.Root, window.Window) error
-	NewWindow(SessionName, template.Root, window.Window) error
+	NewPane(WindowID, template.Root, window.Root, pane.Pane) (PaneID, error)
+	NewSession(SessionName, template.Template) (WindowID, PaneID, error)
+	NewWindow(SessionName, template.Root, window.Window) (WindowID, PaneID, error)
 	SendKeys(PaneID, command.Command) error
-	SetLayout(SessionName, window.Window) error
+	SetLayout(WindowID, window.Layout) error
 	SwitchSession(SessionName) error
 }
 
@@ -42,13 +38,11 @@ const (
 	ErrFailedToCreateSession         problem.Key = "TMUX_FAILED_TO_CREATE_SESSION"
 	ErrFailedToCreateWindow          problem.Key = "TMUX_FAILED_TO_CREATE_WINDOW"
 	ErrFailedToListSessions          problem.Key = "TMUX_FAILED_TO_LIST_SESSIONS"
-	ErrFailedToListPanes             problem.Key = "TMUX_FAILED_TO_LIST_PANES"
 	ErrFailedToKillSession           problem.Key = "TMUX_FAILED_TO_KILL_SESSION"
 	ErrFailedToSendKeys              problem.Key = "TMUX_FAILED_TO_SEND_KEYS"
 	ErrFailedToSetLayout             problem.Key = "TMUX_FAILED_TO_SET_LAYOUT"
 	ErrTriedToBuildFromActiveSession problem.Key = "TMUX_TRIED_TO_BUILD_FROM_ACTIVE_SESSION"
 	ErrFailedToCreatePane            problem.Key = "TMUX_FAILED_TO_CREATE_PANE"
-	ErrInvalidTemplateArgs           problem.Key = "TMUX_INVALID_TEMPLATE_ARGS"
 )
 
 func (c *TmuxClientImpl) IsTmuxServerRunning() bool {
@@ -57,53 +51,29 @@ func (c *TmuxClientImpl) IsTmuxServerRunning() bool {
 	return err == nil
 }
 
-func (c *TmuxClientImpl) AttachSession(session SessionName) error {
-	if session == "" {
-		return ErrInvalidTemplateArgs.WithMsg("session name cannot be empty")
-	}
-
-	cmd := exec.Command("tmux", "attach", "-t", string(session))
+func (c *TmuxClientImpl) AttachSession(sn SessionName) error {
+	cmd := exec.Command("tmux", "attach", "-t", string(sn))
 	cmd.Stdin = os.Stdin // bind tmux session to terminal
 
-	_, _, err := c.E.Execute(cmd)
-	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToAttachSession.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToAttachSession.WithMsg(err.Error())
-		}
+	if _, _, err := c.E.Execute(cmd); err != nil {
+		return buildExitCodeError(ErrFailedToAttachSession, err)
 	}
 
 	return nil
 }
 
-func (c *TmuxClientImpl) SwitchSession(session SessionName) error {
-	if session == "" {
-		return ErrInvalidTemplateArgs.WithMsg("session name cannot be empty")
-	}
+func (c *TmuxClientImpl) SwitchSession(sn SessionName) error {
+	cmd := exec.Command("tmux", "switch", "-t", string(sn))
 
-	cmd := exec.Command("tmux", "switch", "-t", string(session))
-
-	_, _, err := c.E.Execute(cmd)
-	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToSwitchSession.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToSwitchSession.WithMsg(err.Error())
-		}
+	if _, _, err := c.E.Execute(cmd); err != nil {
+		return buildExitCodeError(ErrFailedToSwitchSession, err)
 	}
 
 	return nil
 }
 
-func (c *TmuxClientImpl) HasSession(session SessionName) (bool, error) {
-	if session == "" {
-		return false, ErrInvalidTemplateArgs.WithMsg("session name cannot be empty")
-	}
-
-	cmd := exec.Command("tmux", "has-session", "-t", string(session))
+func (c *TmuxClientImpl) HasSession(sn SessionName) (bool, error) {
+	cmd := exec.Command("tmux", "has-session", "-t", string(sn))
 
 	_, exitCode, err := c.E.Execute(cmd)
 	if err != nil {
@@ -111,98 +81,75 @@ func (c *TmuxClientImpl) HasSession(session SessionName) (bool, error) {
 		if exitCode == 1 {
 			return false, nil
 		}
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return false, ErrFailedToCheckSession.WithMsg(string(err.Stderr))
-		default:
-			return false, ErrFailedToCheckSession.WithMsg(err.Error())
-		}
+		return false, buildExitCodeError(ErrFailedToCheckSession, err)
 	}
 
 	return exitCode == 0, nil
 }
 
-func (c *TmuxClientImpl) NewSession(
-	session SessionName,
-	root template.Root,
-	mainWindow window.Window,
-) error {
-	if anyEmpty(string(session), string(root), string(mainWindow.Name)) {
-		return ErrInvalidTemplateArgs.WithMsg("session, root and window name cannot be empty")
-	}
+func (c *TmuxClientImpl) NewSession(sn SessionName, t template.Template) (WindowID, PaneID, error) {
+	mw := t.Windows[0]
 
 	cmd := exec.Command("tmux", "new-session", "-d")
-	cmd.Args = append(cmd.Args, "-s", string(session))
-	cmd.Args = append(cmd.Args, "-c", string(root))
-	cmd.Args = append(cmd.Args, "-n", string(mainWindow.Name))
+	cmd.Args = append(cmd.Args, "-s", string(sn))
+	cmd.Args = append(cmd.Args, "-c", string(t.Root))
 
-	if mainWindow.Root != "" {
+	if mw.Name != "" {
+		cmd.Args = append(cmd.Args, "-n", string(mw.Name))
+	}
+
+	if mw.Root != "" {
 		// little hack to start first window at different root than session
-		cmd.Args = append(cmd.Args, fmt.Sprintf("cd %s && exec $SHELL", mainWindow.Root))
+		cmd.Args = append(cmd.Args, fmt.Sprintf("cd %s && exec $SHELL", mw.Root))
 	}
 
-	if _, _, err := c.E.Execute(cmd); err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToCreateSession.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToCreateSession.WithMsg(err.Error())
-		}
+	cmd.Args = append(cmd.Args, "-P", "-F", "#{window_id} #{pane_id}")
+
+	o, _, err := c.E.Execute(cmd)
+	if err != nil {
+		return WindowID(o), PaneID(o), buildExitCodeError(ErrFailedToCreateSession, err)
 	}
 
-	return nil
+	o = o[:len(o)-1] // trim newline character
+	output := strings.Split(o, " ")
+	return WindowID(output[0]), PaneID(output[1]), nil
 }
 
-func (c *TmuxClientImpl) NewWindow(
-	session SessionName,
-	root template.Root,
-	mainWindow window.Window,
-) error {
-	if anyEmpty(string(session), string(root), string(mainWindow.Name)) {
-		return ErrInvalidTemplateArgs.WithMsg("session, root and window name cannot be empty")
-	}
-
+func (c *TmuxClientImpl) NewWindow(sn SessionName, tr template.Root, w window.Window) (WindowID, PaneID, error) {
 	cmd := exec.Command("tmux", "new-window", "-d")
-	cmd.Args = append(cmd.Args, "-t", string(session))
-	cmd.Args = append(cmd.Args, "-n", string(mainWindow.Name))
+	cmd.Args = append(cmd.Args, "-t", string(sn))
 
-	if mainWindow.Root != "" {
-		cmd.Args = append(cmd.Args, "-c", string(mainWindow.Root))
+	if w.Name != "" {
+		cmd.Args = append(cmd.Args, "-n", string(w.Name))
+	}
+
+	if w.Root != "" {
+		cmd.Args = append(cmd.Args, "-c", string(w.Root))
 	} else {
-		// in certain scenarios tmux will create window in working directory
-		// instead of the session root, so specify it explicitly
-		cmd.Args = append(cmd.Args, "-c", string(root))
+		// specify the root explicitly, otherwise it will nest at working directory
+		cmd.Args = append(cmd.Args, "-c", string(tr))
 	}
 
-	if _, _, err := c.E.Execute(cmd); err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToCreateWindow.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToCreateWindow.WithMsg(err.Error())
-		}
+	cmd.Args = append(cmd.Args, "-P", "-F", "#{window_id} #{pane_id}")
+
+	o, _, err := c.E.Execute(cmd)
+	if err != nil {
+		return WindowID(o), PaneID(o), buildExitCodeError(ErrFailedToCreateWindow, err)
 	}
 
-	return nil
+	o = o[:len(o)-1] // trim newline character
+	output := strings.Split(o, " ")
 
+	return WindowID(output[0]), PaneID(output[1]), nil
 }
 
-func (c *TmuxClientImpl) SendKeys(paneID PaneID, keys command.Command) error {
-	if anyEmpty(string(paneID), string(keys)) {
-		return ErrInvalidTemplateArgs.WithMsg("pane id and keys cannot be empty")
-	}
-
-	cmd := exec.Command("tmux", "send-keys", "-t", string(paneID))
+func (c *TmuxClientImpl) SendKeys(pID PaneID, keys command.Command) error {
+	cmd := exec.Command("tmux", "send-keys", "-t", string(pID))
 	cmd.Args = append(cmd.Args, string(keys))
 	cmd.Args = append(cmd.Args, "C-m")
 
 	if _, _, err := c.E.Execute(cmd); err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToSendKeys.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToSendKeys.WithMsg(err.Error())
-		}
+		return buildExitCodeError(ErrFailedToSendKeys, err)
 	}
 
 	return nil
@@ -213,12 +160,7 @@ func (c *TmuxClientImpl) ListSessions() ([]SessionName, error) {
 
 	output, _, err := c.E.Execute(cmd)
 	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return nil, ErrFailedToListSessions.WithMsg(string(err.Stderr))
-		default:
-			return nil, ErrFailedToListSessions.WithMsg(err.Error())
-		}
+		return nil, buildExitCodeError(ErrFailedToListSessions, err)
 	}
 
 	var sessionNames []SessionName
@@ -226,110 +168,55 @@ func (c *TmuxClientImpl) ListSessions() ([]SessionName, error) {
 		sessionNames = append(sessionNames, SessionName(line))
 	}
 
-	// drop the last one, it's empty
+	// drop the last one, it's empty since split is done by newline
 	return sessionNames[:len(sessionNames)-1], nil
 }
 
-func (c *TmuxClientImpl) ListPanes(session SessionName, windowName window.Name) ([]PaneID, error) {
-	if anyEmpty(string(session), string(windowName)) {
-		return nil, ErrInvalidTemplateArgs.WithMsg("session and window name cannot be empty")
-	}
+func (c *TmuxClientImpl) KillSession(sn SessionName) error {
+	cmd := exec.Command("tmux", "kill-session", "-t", string(sn))
 
-	cmd := exec.Command("tmux", "list-panes", "-t", fmt.Sprintf("%s:%s", session, windowName))
-	cmd.Args = append(cmd.Args, "-F", "#{pane_id}")
-
-	output, _, err := c.E.Execute(cmd)
-	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return nil, ErrFailedToListPanes.WithMsg(string(err.Stderr))
-		default:
-			return nil, ErrFailedToListPanes.WithMsg(err.Error())
-		}
-	}
-
-	var paneIds []PaneID
-
-	for line := range strings.SplitSeq(output, "\n") {
-		paneIds = append(paneIds, PaneID(line))
-	}
-
-	// drop the last one, it's empty
-	return paneIds[:len(paneIds)-1], nil
-}
-
-func (c *TmuxClientImpl) KillSession(session SessionName) error {
-	if session == "" {
-		return ErrInvalidTemplateArgs.WithMsg("session name cannot be empty")
-	}
-
-	cmd := exec.Command("tmux", "kill-session", "-t", string(session))
-
-	_, _, err := c.E.Execute(cmd)
-	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToKillSession.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToKillSession.WithMsg(err.Error())
-		}
+	if _, _, err := c.E.Execute(cmd); err != nil {
+		return buildExitCodeError(ErrFailedToKillSession, err)
 	}
 
 	return nil
 }
 
-func (c *TmuxClientImpl) NewPane(session SessionName, windowName window.Name, p pane.Pane, fallbackRoot string) error {
-	if anyEmpty(string(session), string(windowName), string(fallbackRoot)) {
-		return ErrInvalidTemplateArgs.WithMsg("session, window name and fallback root cannot be empty")
-	}
-
-	combinedName := fmt.Sprintf("%s:%s", session, windowName)
-	cmd := exec.Command("tmux", "split-window", "-d", "-t", combinedName)
+func (c *TmuxClientImpl) NewPane(
+	wID WindowID,
+	tr template.Root,
+	wr window.Root,
+	p pane.Pane,
+) (PaneID, error) {
+	cmd := exec.Command("tmux", "split-window", "-t", string(wID))
 
 	var root string
+	// pane root > window root > template root
 	if p.Root != "" {
 		root = string(p.Root)
+	} else if wr != "" {
+		root = string(wr)
 	} else {
-		root = fallbackRoot
+		root = string(tr)
 	}
 
 	cmd.Args = append(cmd.Args, "-c", root)
+	cmd.Args = append(cmd.Args, "-P", "-F", "#{pane_id}")
 
-	_, _, err := c.E.Execute(cmd)
-
+	o, _, err := c.E.Execute(cmd)
 	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToCreatePane.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToCreatePane.WithMsg(err.Error())
-		}
+		return PaneID(o), buildExitCodeError(ErrFailedToCreatePane, err)
+	}
+
+	o = o[:len(o)-1] // trim newline character
+	return PaneID(o), nil
+}
+
+func (c *TmuxClientImpl) SetLayout(wID WindowID, l window.Layout) error {
+	cmd := exec.Command("tmux", "select-layout", "-t", string(wID), string(l))
+	if _, _, err := c.E.Execute(cmd); err != nil {
+		return buildExitCodeError(ErrFailedToSetLayout, err)
 	}
 
 	return nil
-}
-
-func (c *TmuxClientImpl) SetLayout(session SessionName, window window.Window) error {
-	if anyEmpty(string(session), string(window.Name), string(window.Layout)) {
-		return ErrInvalidTemplateArgs.WithMsg("session, window name and layout cannot be empty")
-	}
-
-	combinedName := fmt.Sprintf("%s:%s", session, window.Name)
-
-	cmd := exec.Command("tmux", "select-layout", "-t", combinedName, string(window.Layout))
-	_, _, err := c.E.Execute(cmd)
-	if err != nil {
-		switch err := err.(type) {
-		case *exec.ExitError:
-			return ErrFailedToSetLayout.WithMsg(string(err.Stderr))
-		default:
-			return ErrFailedToSetLayout.WithMsg(err.Error())
-		}
-	}
-
-	return nil
-}
-
-func anyEmpty(s ...string) bool {
-	return slices.Contains(s, "")
 }

--- a/internal/multiplexer/tmux_multiplexer_client.go
+++ b/internal/multiplexer/tmux_multiplexer_client.go
@@ -119,6 +119,8 @@ func (c *TmuxClientImpl) NewSession(sn SessionName, t template.Template) (Window
 }
 
 func (c *TmuxClientImpl) NewWindow(sn SessionName, tr template.Root, w window.Window) (WindowID, PaneID, error) {
+	mp := w.Panes[0]
+
 	cmd := exec.Command("tmux", "new-window", "-d")
 	cmd.Args = append(cmd.Args, "-t", string(sn))
 
@@ -134,6 +136,10 @@ func (c *TmuxClientImpl) NewWindow(sn SessionName, tr template.Root, w window.Wi
 	}
 
 	cmd.Args = append(cmd.Args, "-P", "-F", "#{window_id} #{pane_id}")
+
+	if mp.Root != "" {
+		cmd.Args = append(cmd.Args, fmt.Sprintf("cd %s && exec $SHELL", mp.Root))
+	}
 
 	o, _, err := c.E.Execute(cmd)
 	if err != nil {

--- a/internal/multiplexer/tmux_multiplexer_client.go
+++ b/internal/multiplexer/tmux_multiplexer_client.go
@@ -89,6 +89,7 @@ func (c *TmuxClientImpl) HasSession(sn SessionName) (bool, error) {
 
 func (c *TmuxClientImpl) NewSession(sn SessionName, t template.Template) (WindowID, PaneID, error) {
 	mw := t.Windows[0]
+	mp := mw.Panes[0]
 
 	cmd := exec.Command("tmux", "new-session", "-d")
 	cmd.Args = append(cmd.Args, "-s", string(sn))
@@ -98,12 +99,14 @@ func (c *TmuxClientImpl) NewSession(sn SessionName, t template.Template) (Window
 		cmd.Args = append(cmd.Args, "-n", string(mw.Name))
 	}
 
-	if mw.Root != "" {
-		// little hack to start first window at different root than session
+	cmd.Args = append(cmd.Args, "-P", "-F", "#{window_id} #{pane_id}")
+
+	// little hack to start first window at different root than session
+	if mp.Root != "" {
+		cmd.Args = append(cmd.Args, fmt.Sprintf("cd %s && exec $SHELL", mp.Root))
+	} else if mw.Root != "" {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("cd %s && exec $SHELL", mw.Root))
 	}
-
-	cmd.Args = append(cmd.Args, "-P", "-F", "#{window_id} #{pane_id}")
 
 	o, _, err := c.E.Execute(cmd)
 	if err != nil {

--- a/internal/multiplexer/tmux_utils.go
+++ b/internal/multiplexer/tmux_utils.go
@@ -1,0 +1,28 @@
+package multiplexer
+
+import (
+	"os/exec"
+	"thop/internal/problem"
+	"thop/internal/types/project"
+)
+
+type SessionName string
+type PaneID string
+type WindowID string
+
+func buildExitCodeError(key problem.Key, err error) error {
+	switch err := err.(type) {
+	case *exec.ExitError:
+		return key.WithMsg(string(err.Stderr))
+	default:
+		return key.WithMsg(err.Error())
+	}
+}
+
+func resolveSessionName(p project.Project) SessionName {
+	if p.Template.Name != "" {
+		return SessionName(p.Template.Name)
+	}
+
+	return SessionName(p.Name)
+}

--- a/internal/service/app_service.go
+++ b/internal/service/app_service.go
@@ -58,7 +58,7 @@ func (s *AppService) CreateProject(root template.Root, name project.Name) error 
 	p := project.Project{
 		Name:     name,
 		Version:  TemplateVersion,
-		Template: template.WithDefaults(),
+		Template: template,
 	}
 
 	return s.Storage.Save(&p)

--- a/internal/storage/yaml_storage.go
+++ b/internal/storage/yaml_storage.go
@@ -78,7 +78,11 @@ func (s *YamlStorage) List() ([]project.Project, error) {
 		}
 
 		p.UUID = project.UUID(dirName)
-		projects = append(projects, p)
+		p = p.WithDefaults()
+
+		if p.IsValid() {
+			projects = append(projects, p)
+		}
 	}
 
 	return projects, nil
@@ -90,9 +94,13 @@ func (s *YamlStorage) Find(name project.Name) (project.Project, error) {
 		return project.Project{}, err
 	}
 
-	for _, project := range projects {
-		if project.Name == name {
-			return project, nil
+	for _, p := range projects {
+		if p.Name == name {
+			p = p.WithDefaults()
+			if !p.IsValid() {
+				return project.Project{}, ErrProjectNotFound.WithMsg("project", name, "is invalid")
+			}
+			return p, nil
 		}
 	}
 

--- a/internal/types/pane/pane.go
+++ b/internal/types/pane/pane.go
@@ -9,3 +9,8 @@ type Pane struct {
 	Commands []command.Command `yaml:"run,omitempty"`
 	Active   bool              `yaml:"active,omitempty"`
 }
+
+func (p *Pane) IsValid() bool {
+	// For now it is always valid
+	return true
+}

--- a/internal/types/project/project.go
+++ b/internal/types/project/project.go
@@ -22,3 +22,26 @@ type Project struct {
 	Template template.Template `yaml:"template"`
 	Type     ProjectType       `yaml:"-"`
 }
+
+func (p *Project) WithDefaults() Project {
+	newProject := *p
+	newProject.Template = newProject.Template.WithDefaults()
+	return newProject
+}
+
+func (p *Project) IsValid() bool {
+	// for now other types shouldn't be validated at all since they are not meant to be created by user
+	if p.Type != TypeTemplate {
+		panic("only template projects validation is supported")
+	}
+
+	if p.UUID == "" {
+		return false
+	}
+
+	if p.Name == "" {
+		return false
+	}
+
+	return p.Template.IsValid()
+}

--- a/internal/types/template/template.go
+++ b/internal/types/template/template.go
@@ -1,9 +1,7 @@
 package template
 
 import (
-	"strconv"
 	"thop/internal/types/command"
-	"thop/internal/types/pane"
 	"thop/internal/types/window"
 )
 
@@ -30,20 +28,26 @@ func (t *Template) WithDefaults() Template {
 	}
 
 	for i := range newTemplate.Windows {
-		win := &newTemplate.Windows[i]
-
-		if win.Name == "" {
-			win.Name = window.Name("window" + strconv.Itoa(i))
-		}
-
-		if len(win.Panes) == 0 {
-			win.Panes = []pane.Pane{{}}
-		}
-
-		if win.Layout == "" {
-			win.Layout = window.LayoutTiled
-		}
+		newTemplate.Windows[i] = newTemplate.Windows[i].WithDefaults()
 	}
 
 	return newTemplate
+}
+
+func (t *Template) IsValid() bool {
+	if t.Root == "" {
+		return false
+	}
+
+	if len(t.Windows) < 1 { // at least main window is required
+		return false
+	}
+
+	for _, win := range t.Windows {
+		if !win.IsValid() {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/types/window/window.go
+++ b/internal/types/window/window.go
@@ -17,6 +17,14 @@ const (
 	LayoutTiled          = "tiled"
 )
 
+var layouts = map[string]Layout{
+	LayoutEvenHorizontal: LayoutEvenHorizontal,
+	LayoutEvenVertical:   LayoutEvenVertical,
+	LayoutMainHorizontal: LayoutMainHorizontal,
+	LayoutMainVertical:   LayoutMainVertical,
+	LayoutTiled:          LayoutTiled,
+}
+
 type Window struct {
 	Name     Name              `yaml:"name,omitempty"`
 	Root     Root              `yaml:"root,omitempty"`
@@ -24,4 +32,36 @@ type Window struct {
 	Layout   Layout            `yaml:"layout,omitempty"`
 	Panes    []pane.Pane       `yaml:"panes,omitempty"`
 	Active   bool              `yaml:"active,omitempty"`
+}
+
+func (w *Window) WithDefaults() Window {
+	newWindow := *w
+
+	if len(newWindow.Panes) == 0 {
+		newWindow.Panes = []pane.Pane{{}}
+	}
+
+	if newWindow.Layout == "" {
+		newWindow.Layout = LayoutTiled
+	}
+
+	return newWindow
+}
+
+func (w *Window) IsValid() bool {
+	if _, ok := layouts[string(w.Layout)]; !ok {
+		return false
+	}
+
+	if len(w.Panes) < 1 { // at least main pane is required
+		return false
+	}
+
+	for _, p := range w.Panes {
+		if !p.IsValid() {
+			return false
+		}
+	}
+
+	return true
 }

--- a/test/multiplexer/tmux_multiplexer_client_test.go
+++ b/test/multiplexer/tmux_multiplexer_client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"thop/internal/multiplexer"
 	"thop/internal/types/pane"
+	"thop/internal/types/template"
 	"thop/internal/types/window"
 
 	"github.com/stretchr/testify/assert"
@@ -30,17 +31,6 @@ func (m *MockCommandExecutor) ExecuteInteractive(cmd *exec.Cmd) (int, error) {
 }
 
 func Test_Client_AttachSession(t *testing.T) {
-	t.Run("returns error if session name is empty", func(t *testing.T) {
-		// given
-		client := &multiplexer.TmuxClientImpl{}
-
-		// when
-		err := client.AttachSession("")
-
-		// then
-		assert.True(t, multiplexer.ErrInvalidTemplateArgs.Equal(err))
-	})
-
 	t.Run("attaches to session", func(t *testing.T) {
 		// given
 		mockExecutor := new(MockCommandExecutor)
@@ -65,19 +55,6 @@ func Test_Client_AttachSession(t *testing.T) {
 }
 
 func Test_Client_SwitchSession(t *testing.T) {
-	t.Run("returns error if session name is empty", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// when
-		err := client.SwitchSession("")
-
-		// then
-		assert.True(t, multiplexer.ErrInvalidTemplateArgs.Equal(err))
-	})
-
 	t.Run("switches session", func(t *testing.T) {
 		// given
 		mockExecutor := new(MockCommandExecutor)
@@ -102,19 +79,6 @@ func Test_Client_SwitchSession(t *testing.T) {
 }
 
 func Test_Client_HasSession(t *testing.T) {
-	t.Run("returns error if session name is empty", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// when
-		_, err := client.HasSession("")
-
-		// then
-		assert.True(t, multiplexer.ErrInvalidTemplateArgs.Equal(err))
-	})
-
 	t.Run("returns false on exit code 1 gracefully", func(t *testing.T) {
 		// given
 		mockExecutor := new(MockCommandExecutor)
@@ -159,27 +123,6 @@ func Test_Client_HasSession(t *testing.T) {
 }
 
 func Test_Client_NewSession(t *testing.T) {
-	t.Run("returns error when missing required fields", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		win := window.Window{Name: "win"}
-
-		// expect
-		err := client.NewSession("", "root", win)
-		assert.NotNil(t, err, "expected error for empty session name")
-
-		// and
-		err = client.NewSession("sess", "", win)
-		assert.NotNil(t, err, "expected error for empty session root")
-
-		// and
-		err = client.NewSession("sess", "root", window.Window{})
-		assert.NotNil(t, err, "expected error for empty window name")
-	})
-
 	t.Run("returns error if session already exists", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
@@ -196,6 +139,7 @@ func Test_Client_NewSession(t *testing.T) {
 				"-n",
 				"main",
 				"cd /project && exec $SHELL",
+				"-P", "-F", "#{window_id} #{pane_id}",
 			},
 		}
 
@@ -204,8 +148,13 @@ func Test_Client_NewSession(t *testing.T) {
 		}
 
 		// when
-		win := window.Window{Name: "main", Root: "/project"}
-		err := client.NewSession("mysession", "/home/test", win)
+		tmpl := template.Template{
+			Root: "/home/test",
+			Windows: []window.Window{
+				{Name: "main", Root: "/project"},
+			},
+		}
+		_, _, err := client.NewSession("mysession", tmpl)
 
 		// then
 		assert.NotNil(t, err)
@@ -215,7 +164,7 @@ func Test_Client_NewSession(t *testing.T) {
 	t.Run("creates new session", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		executor.On("Execute", mock.Anything).Return("@1 %2\n", 0, nil)
 		expectedCmd := [][]string{
 			{
 				"tmux",
@@ -228,6 +177,7 @@ func Test_Client_NewSession(t *testing.T) {
 				"-n",
 				"main",
 				"cd /project && exec $SHELL",
+				"-P", "-F", "#{window_id} #{pane_id}",
 			},
 		}
 
@@ -236,18 +186,25 @@ func Test_Client_NewSession(t *testing.T) {
 		}
 
 		// when
-		win := window.Window{Name: "main", Root: "/project"}
-		err := client.NewSession("mysession", "/home/test", win)
+		tmpl := template.Template{
+			Root: "/home/test",
+			Windows: []window.Window{
+				{Name: "main", Root: "/project"},
+			},
+		}
+		wID, pID, err := client.NewSession("mysession", tmpl)
 
 		// then
 		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.WindowID("@1"), wID)
+		assert.Equal(t, multiplexer.PaneID("%2"), pID)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
 
 	t.Run("defaults main window root to session root if empty", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		executor.On("Execute", mock.Anything).Return("@1 %2\n", 0, nil)
 		expectedCmd := [][]string{
 			{
 				"tmux",
@@ -259,6 +216,7 @@ func Test_Client_NewSession(t *testing.T) {
 				"/home/test",
 				"-n",
 				"main",
+				"-P", "-F", "#{window_id} #{pane_id}",
 			},
 		}
 
@@ -267,8 +225,13 @@ func Test_Client_NewSession(t *testing.T) {
 		}
 
 		// when
-		win := window.Window{Name: "main", Root: ""}
-		err := client.NewSession("mysession", "/home/test", win)
+		tmpl := template.Template{
+			Root: "/home/test",
+			Windows: []window.Window{
+				{Name: "main", Root: ""},
+			},
+		}
+		_, _, err := client.NewSession("mysession", tmpl)
 
 		// then
 		assert.Nil(t, err)
@@ -277,21 +240,6 @@ func Test_Client_NewSession(t *testing.T) {
 }
 
 func Test_TmuxClient_SendKeys(t *testing.T) {
-	t.Run("returns error when missing required fields", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// expect
-		err := client.SendKeys("", "ls")
-		assert.NotNil(t, err, "expected error for empty pane id")
-
-		// and
-		err = client.SendKeys("%id", "")
-		assert.NotNil(t, err, "expected error for empty keys")
-	})
-
 	t.Run("sends keys to pane", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
@@ -321,29 +269,10 @@ func Test_TmuxClient_SendKeys(t *testing.T) {
 }
 
 func Test_Client_NewWindow(t *testing.T) {
-	t.Run("returns error when missing required fields", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// expect
-		err := client.NewWindow("", "/project", window.Window{Name: "window", Root: "/root"})
-		assert.NotNil(t, err, "expected error for empty session name")
-
-		// and
-		err = client.NewWindow("sess", "/project", window.Window{Name: "", Root: "/root"})
-		assert.NotNil(t, err, "expected error for empty window name")
-
-		// and
-		err = client.NewWindow("sess", "", window.Window{Name: "window", Root: "/root"})
-		assert.NotNil(t, err, "expected error for empty session root")
-	})
-
 	t.Run("includes default seession root if window root is empty", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		executor.On("Execute", mock.Anything).Return("@1 %2\n", 0, nil)
 		expectedCmd := [][]string{
 			{
 				"tmux",
@@ -355,6 +284,7 @@ func Test_Client_NewWindow(t *testing.T) {
 				"main",
 				"-c",
 				"/home/test",
+				"-P", "-F", "#{window_id} #{pane_id}",
 			},
 		}
 
@@ -364,17 +294,19 @@ func Test_Client_NewWindow(t *testing.T) {
 
 		// when
 		win := window.Window{Name: "main", Root: ""}
-		err := client.NewWindow("mysession", "/home/test", win)
+		wID, pID, err := client.NewWindow("mysession", "/home/test", win)
 
 		// then
 		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.WindowID("@1"), wID)
+		assert.Equal(t, multiplexer.PaneID("%2"), pID)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
 
 	t.Run("creates new window", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		executor.On("Execute", mock.Anything).Return("@1 %2\n", 0, nil)
 		expectedCmd := [][]string{
 			{
 				"tmux",
@@ -386,6 +318,7 @@ func Test_Client_NewWindow(t *testing.T) {
 				"main",
 				"-c",
 				"/project",
+				"-P", "-F", "#{window_id} #{pane_id}",
 			},
 		}
 
@@ -395,10 +328,12 @@ func Test_Client_NewWindow(t *testing.T) {
 
 		// when
 		win := window.Window{Name: "main", Root: "/project"}
-		err := client.NewWindow("mysession", "/home/test", win)
+		wID, pID, err := client.NewWindow("mysession", "/home/test", win)
 
 		// then
 		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.WindowID("@1"), wID)
+		assert.Equal(t, multiplexer.PaneID("%2"), pID)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
 }
@@ -483,19 +418,6 @@ func Test_IsTmuxServerRunning(t *testing.T) {
 }
 
 func Test_KillSession(t *testing.T) {
-	t.Run("returns error if session name is empty", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// when
-		err := client.KillSession("")
-
-		// then
-		assert.True(t, multiplexer.ErrInvalidTemplateArgs.Equal(err))
-	})
-
 	t.Run("kills session", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
@@ -518,38 +440,19 @@ func Test_KillSession(t *testing.T) {
 }
 
 func Test_NewPane(t *testing.T) {
-	t.Run("returns error when missing required fields", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// expect
-		err := client.NewPane("", "win", pane.Pane{}, "/home/test")
-		assert.NotNil(t, err, "expected error for empty session name")
-
-		// and
-		err = client.NewPane("sess", "", pane.Pane{}, "/home/test")
-		assert.NotNil(t, err, "expected error for empty window name")
-
-		// and
-		err = client.NewPane("sess", "win", pane.Pane{}, "")
-		assert.NotNil(t, err, "expected error for empty fallback root")
-	})
-
-	t.Run("creates new pane", func(t *testing.T) {
+	t.Run("creates new pane with pane root", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		executor.On("Execute", mock.Anything).Return("%1\n", 0, nil)
 		expectedCmd := [][]string{
 			{
 				"tmux",
 				"split-window",
-				"-d",
 				"-t",
-				"mysession:win",
+				"@1",
 				"-c",
-				"/project",
+				"/pane/root",
+				"-P", "-F", "#{pane_id}",
 			},
 		}
 
@@ -558,26 +461,27 @@ func Test_NewPane(t *testing.T) {
 		}
 
 		// when
-		err := client.NewPane("mysession", "win", pane.Pane{Root: "/project"}, "/home/test")
+		pID, err := client.NewPane("@1", "/template/root", "/window/root", pane.Pane{Root: "/pane/root"})
 
 		// then
 		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.PaneID("%1"), pID)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
 
-	t.Run("creates new pane in fallback root if pane root is empty", func(t *testing.T) {
+	t.Run("creates new pane with window root if pane root is empty", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 0, nil)
+		executor.On("Execute", mock.Anything).Return("%1\n", 0, nil)
 		expectedCmd := [][]string{
 			{
 				"tmux",
 				"split-window",
-				"-d",
 				"-t",
-				"mysession:win",
+				"@1",
 				"-c",
-				"/home/test",
+				"/window/root",
+				"-P", "-F", "#{pane_id}",
 			},
 		}
 
@@ -586,10 +490,40 @@ func Test_NewPane(t *testing.T) {
 		}
 
 		// when
-		err := client.NewPane("mysession", "win", pane.Pane{}, "/home/test")
+		pID, err := client.NewPane("@1", "/template/root", "/window/root", pane.Pane{})
 
 		// then
 		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.PaneID("%1"), pID)
+		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
+	})
+
+	t.Run("creates new pane with template root if pane and window root are empty", func(t *testing.T) {
+		// given
+		executor := new(MockCommandExecutor)
+		executor.On("Execute", mock.Anything).Return("%1\n", 0, nil)
+		expectedCmd := [][]string{
+			{
+				"tmux",
+				"split-window",
+				"-t",
+				"@1",
+				"-c",
+				"/template/root",
+				"-P", "-F", "#{pane_id}",
+			},
+		}
+
+		client := multiplexer.TmuxClientImpl{
+			E: executor,
+		}
+
+		// when
+		pID, err := client.NewPane("@1", "/template/root", "", pane.Pane{})
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.PaneID("%1"), pID)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
 
@@ -603,7 +537,7 @@ func Test_NewPane(t *testing.T) {
 		}
 
 		// when
-		err := client.NewPane("mysession", "win", pane.Pane{}, "/home/test")
+		_, err := client.NewPane("@1", "/template/root", "", pane.Pane{})
 
 		// then
 		assert.True(t, multiplexer.ErrFailedToCreatePane.Equal(err))
@@ -611,84 +545,13 @@ func Test_NewPane(t *testing.T) {
 	})
 }
 
-func Test_ListPanes(t *testing.T) {
-	t.Run("returns error when missing required fields", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// expect
-		_, err := client.ListPanes("", "win")
-		assert.NotNil(t, err, "expected error for empty session name")
-
-		// and
-		_, err = client.ListPanes("mysession", "")
-		assert.NotNil(t, err, "expected error for empty window name")
-	})
-
-	t.Run("returns list of panes", func(t *testing.T) {
-		// given
-		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("foo\nbar\nbaz\n", 0, nil).Once()
-
-		expectedCmd := [][]string{
-			{"tmux", "list-panes", "-t", "mysession:win", "-F", "#{pane_id}"},
-		}
-
-		client := multiplexer.TmuxClientImpl{
-			E: executor,
-		}
-
-		// when
-		panes, err := client.ListPanes("mysession", "win")
-
-		// then
-		assert.Nil(t, err)
-		assert.Equal(t, []multiplexer.PaneID{"foo", "bar", "baz"}, panes)
-		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
-	})
-
-	t.Run("returns mapped error if command fails", func(t *testing.T) {
-		// given
-		executor := new(MockCommandExecutor)
-		executor.On("Execute", mock.Anything).Return("", 1, errors.New("exit code 1")).Once()
-
-		client := multiplexer.TmuxClientImpl{
-			E: executor,
-		}
-
-		// when
-		_, err := client.ListPanes("mysession", "win")
-
-		// then
-		assert.True(t, multiplexer.ErrFailedToListPanes.Equal(err))
-		executor.AssertExpectations(t)
-	})
-}
-
 func Test_SetLayout(t *testing.T) {
-	t.Run("returns error if missing required fields", func(t *testing.T) {
-		// given
-		client := multiplexer.TmuxClientImpl{
-			E: nil,
-		}
-
-		// expect
-		err := client.SetLayout("", window.Window{})
-		assert.NotNil(t, err, "expected error for empty session name")
-
-		// and
-		err = client.SetLayout("mysession", window.Window{})
-		assert.NotNil(t, err, "expected error for empty window")
-	})
-
 	t.Run("sets layout", func(t *testing.T) {
 		// given
 		executor := new(MockCommandExecutor)
 		executor.On("Execute", mock.Anything).Return("", 0, nil)
 		expectedCmd := [][]string{
-			{"tmux", "select-layout", "-t", "mysession:main", "tiled"},
+			{"tmux", "select-layout", "-t", "@1", "tiled"},
 		}
 
 		client := multiplexer.TmuxClientImpl{
@@ -696,7 +559,7 @@ func Test_SetLayout(t *testing.T) {
 		}
 
 		// when
-		err := client.SetLayout("mysession", window.Window{Name: "main", Layout: window.LayoutTiled})
+		err := client.SetLayout("@1", window.LayoutTiled)
 
 		// then
 		assert.Nil(t, err)
@@ -713,7 +576,7 @@ func Test_SetLayout(t *testing.T) {
 		}
 
 		// when
-		err := client.SetLayout("mysession", window.Window{Name: "main", Layout: window.LayoutTiled})
+		err := client.SetLayout("@1", window.LayoutTiled)
 
 		// then
 		assert.True(t, multiplexer.ErrFailedToSetLayout.Equal(err))

--- a/test/multiplexer/tmux_multiplexer_client_test.go
+++ b/test/multiplexer/tmux_multiplexer_client_test.go
@@ -138,8 +138,8 @@ func Test_Client_NewSession(t *testing.T) {
 				"/home/test",
 				"-n",
 				"main",
-				"cd /project && exec $SHELL",
 				"-P", "-F", "#{window_id} #{pane_id}",
+				"cd /project && exec $SHELL",
 			},
 		}
 
@@ -151,7 +151,11 @@ func Test_Client_NewSession(t *testing.T) {
 		tmpl := template.Template{
 			Root: "/home/test",
 			Windows: []window.Window{
-				{Name: "main", Root: "/project"},
+				{
+					Name:  "main",
+					Root:  "/project",
+					Panes: []pane.Pane{{}},
+				},
 			},
 		}
 		_, _, err := client.NewSession("mysession", tmpl)
@@ -176,8 +180,8 @@ func Test_Client_NewSession(t *testing.T) {
 				"/home/test",
 				"-n",
 				"main",
-				"cd /project && exec $SHELL",
 				"-P", "-F", "#{window_id} #{pane_id}",
+				"cd /project && exec $SHELL",
 			},
 		}
 
@@ -189,7 +193,11 @@ func Test_Client_NewSession(t *testing.T) {
 		tmpl := template.Template{
 			Root: "/home/test",
 			Windows: []window.Window{
-				{Name: "main", Root: "/project"},
+				{
+					Name:  "main",
+					Root:  "/project",
+					Panes: []pane.Pane{{}},
+				},
 			},
 		}
 		wID, pID, err := client.NewSession("mysession", tmpl)
@@ -228,13 +236,65 @@ func Test_Client_NewSession(t *testing.T) {
 		tmpl := template.Template{
 			Root: "/home/test",
 			Windows: []window.Window{
-				{Name: "main", Root: ""},
+				{
+					Name:  "main",
+					Root:  "",
+					Panes: []pane.Pane{{}},
+				},
 			},
 		}
 		_, _, err := client.NewSession("mysession", tmpl)
 
 		// then
 		assert.Nil(t, err)
+		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
+	})
+
+	t.Run("creates new session with pane root", func(t *testing.T) {
+		// given
+		executor := new(MockCommandExecutor)
+		executor.On("Execute", mock.Anything).Return("@1 %2\n", 0, nil)
+		expectedCmd := [][]string{
+			{
+				"tmux",
+				"new-session",
+				"-d",
+				"-s",
+				"mysession",
+				"-c",
+				"/home/test",
+				"-n",
+				"main",
+				"-P", "-F", "#{window_id} #{pane_id}",
+				"cd /project/pane && exec $SHELL",
+			},
+		}
+
+		client := multiplexer.TmuxClientImpl{
+			E: executor,
+		}
+
+		// when
+		tmpl := template.Template{
+			Root: "/home/test",
+			Windows: []window.Window{
+				{
+					Name: "main",
+					Root: "/project",
+					Panes: []pane.Pane{
+						{
+							Root: "/project/pane",
+						},
+					},
+				},
+			},
+		}
+		wID, pID, err := client.NewSession("mysession", tmpl)
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.WindowID("@1"), wID)
+		assert.Equal(t, multiplexer.PaneID("%2"), pID)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
 }
@@ -293,7 +353,7 @@ func Test_Client_NewWindow(t *testing.T) {
 		}
 
 		// when
-		win := window.Window{Name: "main", Root: ""}
+		win := window.Window{Name: "main", Root: "", Panes: []pane.Pane{{}}}
 		wID, pID, err := client.NewWindow("mysession", "/home/test", win)
 
 		// then
@@ -327,7 +387,50 @@ func Test_Client_NewWindow(t *testing.T) {
 		}
 
 		// when
-		win := window.Window{Name: "main", Root: "/project"}
+		win := window.Window{Name: "main", Root: "/project", Panes: []pane.Pane{{}}}
+		wID, pID, err := client.NewWindow("mysession", "/home/test", win)
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, multiplexer.WindowID("@1"), wID)
+		assert.Equal(t, multiplexer.PaneID("%2"), pID)
+		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
+	})
+
+	t.Run("creates new window with pane root", func(t *testing.T) {
+		// given
+		executor := new(MockCommandExecutor)
+		executor.On("Execute", mock.Anything).Return("@1 %2\n", 0, nil)
+		expectedCmd := [][]string{
+			{
+				"tmux",
+				"new-window",
+				"-d",
+				"-t",
+				"mysession",
+				"-n",
+				"main",
+				"-c",
+				"/project",
+				"-P", "-F", "#{window_id} #{pane_id}",
+				"cd /project/pane && exec $SHELL",
+			},
+		}
+
+		client := multiplexer.TmuxClientImpl{
+			E: executor,
+		}
+
+		// when
+		win := window.Window{
+			Name: "main",
+			Root: "/project",
+			Panes: []pane.Pane{
+				{
+					Root: "/project/pane",
+				},
+			},
+		}
 		wID, pID, err := client.NewWindow("mysession", "/home/test", win)
 
 		// then

--- a/test/multiplexer/tmux_multiplexer_test.go
+++ b/test/multiplexer/tmux_multiplexer_test.go
@@ -18,8 +18,8 @@ type MockTmuxClient struct {
 	mock.Mock
 }
 
-func (m *MockTmuxClient) AttachSession(session multiplexer.SessionName) error {
-	args := m.Called(session)
+func (m *MockTmuxClient) AttachSession(sn multiplexer.SessionName) error {
+	args := m.Called(sn)
 	return args.Error(0)
 }
 
@@ -34,21 +34,20 @@ func (m *MockTmuxClient) HasSession(session multiplexer.SessionName) (bool, erro
 }
 
 func (m *MockTmuxClient) NewSession(
-	session multiplexer.SessionName,
-	root template.Root,
-	win window.Window,
-) error {
-	args := m.Called(session, root, win)
-	return args.Error(0)
+	sn multiplexer.SessionName,
+	t template.Template,
+) (multiplexer.WindowID, multiplexer.PaneID, error) {
+	args := m.Called(sn, t)
+	return args.Get(0).(multiplexer.WindowID), args.Get(1).(multiplexer.PaneID), args.Error(2)
 }
 
 func (m *MockTmuxClient) NewWindow(
 	session multiplexer.SessionName,
 	root template.Root,
 	win window.Window,
-) error {
+) (multiplexer.WindowID, multiplexer.PaneID, error) {
 	args := m.Called(session, root, win)
-	return args.Error(0)
+	return args.Get(0).(multiplexer.WindowID), args.Get(1).(multiplexer.PaneID), args.Error(2)
 }
 
 func (m *MockTmuxClient) SendKeys(
@@ -74,29 +73,32 @@ func (m *MockTmuxClient) KillSession(session multiplexer.SessionName) error {
 	return args.Error(0)
 }
 
-func (m *MockTmuxClient) NewPane(session multiplexer.SessionName, win window.Name, p pane.Pane, fallbackRoot string) error {
-	args := m.Called(session, win, p, fallbackRoot)
-	return args.Error(0)
+func (m *MockTmuxClient) NewPane(
+	wID multiplexer.WindowID,
+	tr template.Root,
+	wr window.Root,
+	p pane.Pane,
+) (multiplexer.PaneID, error) {
+	args := m.Called(wID, tr, wr, p)
+	return args.Get(0).(multiplexer.PaneID), args.Error(1)
 }
 
-func (m *MockTmuxClient) ListPanes(session multiplexer.SessionName, windowName window.Name) ([]multiplexer.PaneID, error) {
-	args := m.Called(session, windowName)
-	return args.Get(0).([]multiplexer.PaneID), args.Error(1)
-}
-
-func (m *MockTmuxClient) SetLayout(session multiplexer.SessionName, window window.Window) error {
-	args := m.Called(session, window)
+func (m *MockTmuxClient) SetLayout(wID multiplexer.WindowID, wl window.Layout) error {
+	args := m.Called(wID, wl)
 	return args.Error(0)
 }
 
 func Test_AttachProject(t *testing.T) {
 	t.Run("assembles and attaches to session if it doesn't exist", func(t *testing.T) {
 		// given
-		sessionName := multiplexer.SessionName("foo")
+		sn := multiplexer.SessionName("foo")
 		root := template.Root("/home/test")
-		window1Name := window.Name("main")
-		window2Name := window.Name("baz")
-		project := project.Project{
+		w1ID := multiplexer.WindowID("A")
+		w2ID := multiplexer.WindowID("B")
+		p1ID := multiplexer.PaneID("C")
+		p2ID := multiplexer.PaneID("D")
+		p3ID := multiplexer.PaneID("E")
+		p := project.Project{
 			UUID: "uuid",
 			Name: "foo",
 			Template: template.Template{
@@ -104,13 +106,11 @@ func Test_AttachProject(t *testing.T) {
 				Commands: []command.Command{"echo hello"},
 				Windows: []window.Window{
 					{
-						Name:   window1Name,
 						Root:   "/project",
 						Panes:  []pane.Pane{{}},
 						Layout: window.LayoutTiled,
 					},
 					{
-						Name:     window2Name,
 						Commands: []command.Command{"ls"},
 						Panes: []pane.Pane{
 							{},
@@ -125,36 +125,33 @@ func Test_AttachProject(t *testing.T) {
 		}
 
 		mockClient := new(MockTmuxClient)
-		mockClient.On("HasSession", sessionName).Return(false, nil).Once()
-		mockClient.On("NewSession", sessionName, root, project.Template.Windows[0]).Return(nil).Once()
-		mockClient.On("NewWindow", sessionName, root, project.Template.Windows[1]).Return(nil).Once()
-		mockClient.On("NewPane", sessionName, window2Name, project.Template.Windows[1].Panes[1], string(root)).Return(nil).Once()
+		mockClient.On("HasSession", sn).Return(false, nil).Once()
+		mockClient.On("NewSession", sn, p.Template).Return(w1ID, p1ID, nil).Once()
+		mockClient.On("NewWindow", sn, root, p.Template.Windows[1]).Return(w2ID, p2ID, nil).Once()
+		mockClient.On("NewPane", w2ID, root, p.Template.Windows[1].Root, p.Template.Windows[1].Panes[1]).Return(p3ID, nil).Once()
 
-		mockClient.On("SetLayout", sessionName, project.Template.Windows[1]).Return(nil)
+		mockClient.On("SetLayout", w2ID, p.Template.Windows[1].Layout).Return(nil)
 
-		mockClient.On("ListPanes", sessionName, window1Name).Return([]multiplexer.PaneID{"A"}, nil).Once()
-		mockClient.On("ListPanes", sessionName, window2Name).Return([]multiplexer.PaneID{"B", "C"}, nil).Once()
+		mockClient.On("SendKeys", p1ID, command.Command("echo hello")).Return(nil).Once()
 
-		mockClient.On("SendKeys", multiplexer.PaneID("A"), command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, command.Command("ls")).Return(nil).Once()
 
-		mockClient.On("SendKeys", multiplexer.PaneID("B"), command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", multiplexer.PaneID("B"), command.Command("ls")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, command.Command("ls")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, command.Command("echo pane")).Return(nil).Once()
 
-		mockClient.On("SendKeys", multiplexer.PaneID("C"), command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", multiplexer.PaneID("C"), command.Command("ls")).Return(nil).Once()
-		mockClient.On("SendKeys", multiplexer.PaneID("C"), command.Command("echo pane")).Return(nil).Once()
-
-		mockClient.On("AttachSession", sessionName).Return(nil).Once()
+		mockClient.On("AttachSession", sn).Return(nil).Once()
 
 		multiplexer := multiplexer.TmuxMultiplexer{
 			Client: mockClient,
 		}
 
 		// when
-		err := multiplexer.AttachProject(project)
+		err := multiplexer.AttachProject(p)
 
 		// then
-		assert.Nil(t, err, "Expected no error")
+		assert.Nil(t, err)
 		mockClient.AssertExpectations(t)
 	})
 
@@ -162,8 +159,7 @@ func Test_AttachProject(t *testing.T) {
 		// given
 		sessionName := multiplexer.SessionName("foo")
 		root := template.Root("/home/test")
-		window1Name := window.Name("main")
-		project := project.Project{
+		p := project.Project{
 			UUID: "uuid",
 			Name: "foo",
 			Template: template.Template{
@@ -171,9 +167,18 @@ func Test_AttachProject(t *testing.T) {
 				Commands: []command.Command{"echo hello"},
 				Windows: []window.Window{
 					{
-						Name:   window1Name,
 						Root:   "/project",
 						Panes:  []pane.Pane{{}},
+						Layout: window.LayoutTiled,
+					},
+					{
+						Commands: []command.Command{"ls"},
+						Panes: []pane.Pane{
+							{},
+							{
+								Commands: []command.Command{"echo pane"},
+							},
+						},
 						Layout: window.LayoutTiled,
 					},
 				},
@@ -182,9 +187,9 @@ func Test_AttachProject(t *testing.T) {
 
 		mockClient := new(MockTmuxClient)
 		mockClient.On("HasSession", sessionName).Return(false, nil).Once()
-		mockClient.On("NewSession", sessionName, root, project.Template.Windows[0]).Return(nil).Once()
+		mockClient.On("NewSession", sessionName, p.Template).Return(multiplexer.WindowID(""), multiplexer.PaneID(""), nil).Once()
 		expectedErr := errors.New("some error")
-		mockClient.On("ListPanes", sessionName, window1Name).Return([]multiplexer.PaneID(nil), expectedErr).Once()
+		mockClient.On("NewWindow", sessionName, root, p.Template.Windows[1]).Return(multiplexer.WindowID(""), multiplexer.PaneID(""), expectedErr).Once()
 		mockClient.On("KillSession", sessionName).Return(nil).Once()
 
 		multiplexer := multiplexer.TmuxMultiplexer{
@@ -192,7 +197,7 @@ func Test_AttachProject(t *testing.T) {
 		}
 
 		// when
-		err := multiplexer.AttachProject(project)
+		err := multiplexer.AttachProject(p)
 
 		// then
 		assert.Equal(t, expectedErr, err)
@@ -227,11 +232,14 @@ func Test_AttachProject(t *testing.T) {
 
 	t.Run("assembles and switches to session if it doesn't exist and shell is in active session", func(t *testing.T) {
 		// given
-		sessionName := multiplexer.SessionName("foo")
+		sn := multiplexer.SessionName("foo")
 		root := template.Root("/home/test")
-		window1Name := window.Name("main")
-		window2Name := window.Name("baz")
-		project := project.Project{
+		w1ID := multiplexer.WindowID("A")
+		w2ID := multiplexer.WindowID("B")
+		p1ID := multiplexer.PaneID("C")
+		p2ID := multiplexer.PaneID("D")
+		p3ID := multiplexer.PaneID("E")
+		p := project.Project{
 			UUID: "uuid",
 			Name: "foo",
 			Template: template.Template{
@@ -239,13 +247,11 @@ func Test_AttachProject(t *testing.T) {
 				Commands: []command.Command{"echo hello"},
 				Windows: []window.Window{
 					{
-						Name:   window1Name,
 						Root:   "/project",
 						Panes:  []pane.Pane{{}},
 						Layout: window.LayoutTiled,
 					},
 					{
-						Name:     window2Name,
 						Commands: []command.Command{"ls"},
 						Panes: []pane.Pane{
 							{},
@@ -253,33 +259,30 @@ func Test_AttachProject(t *testing.T) {
 								Commands: []command.Command{"echo pane"},
 							},
 						},
-						Layout: window.LayoutTiled,
+						Layout: window.LayoutMainVertical,
 					},
 				},
 			},
 		}
 
 		mockClient := new(MockTmuxClient)
-		mockClient.On("HasSession", sessionName).Return(false, nil).Once()
-		mockClient.On("NewSession", sessionName, root, project.Template.Windows[0]).Return(nil).Once()
-		mockClient.On("NewWindow", sessionName, root, project.Template.Windows[1]).Return(nil).Once()
-		mockClient.On("NewPane", sessionName, window2Name, project.Template.Windows[1].Panes[1], string(root)).Return(nil).Once()
+		mockClient.On("HasSession", sn).Return(false, nil).Once()
+		mockClient.On("NewSession", sn, p.Template).Return(w1ID, p1ID, nil).Once()
+		mockClient.On("NewWindow", sn, root, p.Template.Windows[1]).Return(w2ID, p2ID, nil).Once()
+		mockClient.On("NewPane", w2ID, root, p.Template.Windows[1].Root, p.Template.Windows[1].Panes[1]).Return(p3ID, nil).Once()
 
-		mockClient.On("SetLayout", sessionName, project.Template.Windows[1]).Return(nil)
+		mockClient.On("SetLayout", w2ID, p.Template.Windows[1].Layout).Return(nil)
 
-		mockClient.On("ListPanes", sessionName, window1Name).Return([]multiplexer.PaneID{"A"}, nil).Once()
-		mockClient.On("ListPanes", sessionName, window2Name).Return([]multiplexer.PaneID{"B", "C"}, nil).Once()
+		mockClient.On("SendKeys", p1ID, command.Command("echo hello")).Return(nil).Once()
 
-		mockClient.On("SendKeys", multiplexer.PaneID("A"), command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, command.Command("ls")).Return(nil).Once()
 
-		mockClient.On("SendKeys", multiplexer.PaneID("B"), command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", multiplexer.PaneID("B"), command.Command("ls")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, command.Command("ls")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, command.Command("echo pane")).Return(nil).Once()
 
-		mockClient.On("SendKeys", multiplexer.PaneID("C"), command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", multiplexer.PaneID("C"), command.Command("ls")).Return(nil).Once()
-		mockClient.On("SendKeys", multiplexer.PaneID("C"), command.Command("echo pane")).Return(nil).Once()
-
-		mockClient.On("SwitchSession", sessionName).Return(nil).Once()
+		mockClient.On("SwitchSession", sn).Return(nil).Once()
 
 		multiplexer := multiplexer.TmuxMultiplexer{
 			Client:            mockClient,
@@ -287,10 +290,10 @@ func Test_AttachProject(t *testing.T) {
 		}
 
 		// when
-		err := multiplexer.AttachProject(project)
+		err := multiplexer.AttachProject(p)
 
 		// then
-		assert.Nil(t, err, "Expected no error")
+		assert.Nil(t, err)
 		mockClient.AssertExpectations(t)
 	})
 
@@ -346,15 +349,6 @@ func Test_AttachProject(t *testing.T) {
 		// then
 		assert.Nil(t, err, "Expected no error")
 		mockClient.AssertExpectations(t)
-	})
-
-	t.Run("returns error if project has no name", func(t *testing.T) {
-		multiplexer := multiplexer.TmuxMultiplexer{
-			Client: nil,
-		}
-
-		err := multiplexer.AttachProject(project.Project{Name: "", Template: template.Template{Name: ""}})
-		assert.NotNil(t, err, "Expected error when project has no name")
 	})
 }
 

--- a/test/storage/yaml_storage_test.go
+++ b/test/storage/yaml_storage_test.go
@@ -63,6 +63,10 @@ func Test_List(t *testing.T) {
 			{UUID: "baz", Name: "foobar", Template: template.Template{Root: "/home/test"}},
 		}
 
+		for i := range expectedProjects {
+			expectedProjects[i] = expectedProjects[i].WithDefaults()
+		}
+
 		st := &storage.YamlStorage{Config: cfg, FileSystem: fs}
 
 		// when
@@ -157,6 +161,7 @@ func Test_Find(t *testing.T) {
 
 		// when
 		project, err := st.Find(expectedProject.Name)
+		expectedProject = expectedProject.WithDefaults()
 
 		// then
 		assert.Nil(t, err)

--- a/test/types/pane/pane_test.go
+++ b/test/types/pane/pane_test.go
@@ -1,0 +1,21 @@
+package pane_test
+
+import (
+	"testing"
+	"thop/internal/types/pane"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPane_IsValid(t *testing.T) {
+	t.Run("should always return true", func(t *testing.T) {
+		// given
+		p := pane.Pane{}
+
+		// when
+		isValid := p.IsValid()
+
+		// then
+		assert.True(t, isValid)
+	})
+}

--- a/test/types/project/project_test.go
+++ b/test/types/project/project_test.go
@@ -1,0 +1,134 @@
+package project_test
+
+import (
+	"testing"
+	"thop/internal/types/pane"
+	"thop/internal/types/project"
+	"thop/internal/types/template"
+	"thop/internal/types/window"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProject_WithDefaults(t *testing.T) {
+	t.Run("should set defaults for template", func(t *testing.T) {
+		// given
+		p := project.Project{
+			Template: template.Template{
+				Root: "/foo",
+			},
+		}
+
+		// when
+		newP := p.WithDefaults()
+
+		// then
+		assert.Len(t, newP.Template.Windows, 1)
+		assert.Equal(t, window.Layout(window.LayoutTiled), newP.Template.Windows[0].Layout)
+		assert.Len(t, newP.Template.Windows[0].Panes, 1)
+	})
+}
+
+func TestProject_IsValid(t *testing.T) {
+	t.Run("should return true for minimum valid project", func(t *testing.T) {
+		// given
+		p := project.Project{
+			UUID: "some-uuid",
+			Name: "my-project",
+			Type: project.TypeTemplate,
+			Template: template.Template{
+				Root: "/foo",
+				Windows: []window.Window{
+					{
+						Layout: window.LayoutTiled,
+						Panes:  []pane.Pane{{}},
+					},
+				},
+			},
+		}
+
+		// when
+		isValid := p.IsValid()
+
+		// then
+		assert.True(t, isValid)
+	})
+
+	t.Run("should return false for empty UUID", func(t *testing.T) {
+		// given
+		p := project.Project{
+			UUID: "",
+			Name: "my-project",
+			Type: project.TypeTemplate,
+			Template: template.Template{
+				Root: "/foo",
+				Windows: []window.Window{
+					{
+						Layout: window.LayoutTiled,
+						Panes:  []pane.Pane{{}},
+					},
+				},
+			},
+		}
+
+		// when
+		isValid := p.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("should return false for empty name", func(t *testing.T) {
+		// given
+		p := project.Project{
+			UUID: "some-uuid",
+			Name: "",
+			Type: project.TypeTemplate,
+			Template: template.Template{
+				Root: "/foo",
+				Windows: []window.Window{
+					{
+						Layout: window.LayoutTiled,
+						Panes:  []pane.Pane{{}},
+					},
+				},
+			},
+		}
+
+		// when
+		isValid := p.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("should return false for invalid template", func(t *testing.T) {
+		// given
+		p := project.Project{
+			UUID:     "some-uuid",
+			Name:     "my-project",
+			Type:     project.TypeTemplate,
+			Template: template.Template{
+				// Root is missing
+			},
+		}
+
+		// when
+		isValid := p.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("should panic for non-template project type", func(t *testing.T) {
+		// given
+		p := project.Project{
+			Type: project.TypeTmuxSession,
+		}
+
+		// then
+		assert.Panics(t, func() {
+			p.IsValid()
+		})
+	})
+}

--- a/test/types/template/template_test.go
+++ b/test/types/template/template_test.go
@@ -22,13 +22,12 @@ func Test_WithDefaults(t *testing.T) {
 
 		// then
 		assert.Equal(t, template.Root("/foo/bar"), temp.Root)
-		assert.Equal(t, window.Name("window0"), temp.Windows[0].Name)
 		assert.Equal(t, pane.Pane{}, temp.Windows[0].Panes[0])
 	})
 
 	t.Run("fills windows with panes", func(t *testing.T) {
 		// given
-		template := template.Template{
+		temp := template.Template{
 			Root: "/foo/bar",
 			Windows: []window.Window{
 				{
@@ -46,28 +45,83 @@ func Test_WithDefaults(t *testing.T) {
 		}
 
 		// when
-		template = template.WithDefaults()
+		temp = temp.WithDefaults()
 
 		// then
-		assert.Equal(t, pane.Pane{Commands: []command.Command{"echo foo"}}, template.Windows[0].Panes[0])
-		assert.Equal(t, pane.Pane{}, template.Windows[1].Panes[0])
+		assert.Equal(t, pane.Pane{Commands: []command.Command{"echo foo"}}, temp.Windows[0].Panes[0])
+		assert.Equal(t, pane.Pane{}, temp.Windows[1].Panes[0])
 	})
+}
 
-	t.Run("fills window names", func(t *testing.T) {
+func Test_IsValid(t *testing.T) {
+	t.Run("returns true for valid template", func(t *testing.T) {
 		// given
-		template := template.Template{
+		temp := template.Template{
 			Root: "/foo/bar",
 			Windows: []window.Window{
 				{
-					Name: "",
+					Layout: window.LayoutTiled,
+					Panes:  []pane.Pane{{}},
 				},
 			},
 		}
 
 		// when
-		newTemplate := template.WithDefaults()
+		isValid := temp.IsValid()
 
 		// then
-		assert.Equal(t, window.Name("window0"), newTemplate.Windows[0].Name)
+		assert.True(t, isValid)
+	})
+
+	t.Run("returns false if root is empty", func(t *testing.T) {
+		// given
+		temp := template.Template{
+			Root: "",
+			Windows: []window.Window{
+				{
+					Layout: window.LayoutTiled,
+					Panes:  []pane.Pane{{}},
+				},
+			},
+		}
+
+		// when
+		isValid := temp.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("returns false if no windows", func(t *testing.T) {
+		// given
+		temp := template.Template{
+			Root:    "/foo/bar",
+			Windows: []window.Window{},
+		}
+
+		// when
+		isValid := temp.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("returns false if any window is invalid", func(t *testing.T) {
+		// given
+		temp := template.Template{
+			Root: "/foo/bar",
+			Windows: []window.Window{
+				{
+					Layout: "invalid-layout", // Invalid layout
+					Panes:  []pane.Pane{{}},
+				},
+			},
+		}
+
+		// when
+		isValid := temp.IsValid()
+
+		// then
+		assert.False(t, isValid)
 	})
 }

--- a/test/types/window/window_test.go
+++ b/test/types/window/window_test.go
@@ -1,0 +1,102 @@
+package window_test
+
+import (
+	"testing"
+	"thop/internal/types/pane"
+	"thop/internal/types/window"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWindow_WithDefaults(t *testing.T) {
+	t.Run("should set default values for empty window", func(t *testing.T) {
+		// given
+		w := window.Window{}
+
+		// when
+		newW := w.WithDefaults()
+
+		// then
+		assert.Equal(t, window.Layout(window.LayoutTiled), newW.Layout)
+		assert.Len(t, newW.Panes, 1)
+		assert.Equal(t, pane.Pane{}, newW.Panes[0])
+	})
+
+	t.Run("should not override existing values", func(t *testing.T) {
+		// given
+		w := window.Window{
+			Name:   "my-window",
+			Layout: window.LayoutEvenHorizontal,
+			Panes: []pane.Pane{
+				{Root: "/tmp"},
+			},
+		}
+
+		// when
+		newW := w.WithDefaults()
+
+		// then
+		assert.Equal(t, window.Name("my-window"), newW.Name)
+		assert.Equal(t, window.Layout(window.LayoutEvenHorizontal), newW.Layout)
+		assert.Len(t, newW.Panes, 1)
+		assert.Equal(t, pane.Pane{Root: "/tmp"}, newW.Panes[0])
+	})
+}
+
+func TestWindow_IsValid(t *testing.T) {
+	t.Run("should return true for a valid window", func(t *testing.T) {
+		// given
+		w := window.Window{
+			Layout: window.LayoutTiled,
+			Panes:  []pane.Pane{{}},
+		}
+
+		// when
+		isValid := w.IsValid()
+
+		// then
+		assert.True(t, isValid)
+	})
+
+	t.Run("should return false for an invalid layout", func(t *testing.T) {
+		// given
+		w := window.Window{
+			Layout: "invalid-layout",
+			Panes:  []pane.Pane{{}},
+		}
+
+		// when
+		isValid := w.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("should return false if there are no panes", func(t *testing.T) {
+		// given
+		w := window.Window{
+			Layout: window.LayoutTiled,
+			Panes:  []pane.Pane{},
+		}
+
+		// when
+		isValid := w.IsValid()
+
+		// then
+		assert.False(t, isValid)
+	})
+
+	t.Run("name is not required", func(t *testing.T) {
+		// given
+		w := window.Window{
+			Layout: window.LayoutTiled,
+			Panes:  []pane.Pane{{}},
+		}
+
+		// when
+		isValid := w.IsValid()
+
+		// then
+		assert.True(t, isValid)
+	})
+}


### PR DESCRIPTION
This PR improves logic handling for multiplexer, fixing potential future issues, it maps the windows and panes to tmux ID's for later further execution of commands etc

Also new: window name is now no longer a required property and first pane can have working root passed to it

Validation logic also got improved in this PR, so rest of the code assumes the project loaded by yaml storage is already validated and defaulted