### PR TITLE
Run accepts multi-line string instead of array (breaks templates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,22 @@ version: 1                                  # Version of the template, used for 
 template:
   name: Optional session name               # Name of the session, will use project name if not present
   root: /home/foobar/projects/some_project  # Root directory for this session
-  run:                                      # List of commands to be executed in all windows
-  - echo 'Hello world'
+  run: echo 'Hello world'                   # Multiline string for shell commands to be executed in this session
   windows:                                  # List of windows to be created
   - name: main                              # Name of the window
     root: /optional/root/dir                # Root directory for this window
     layout: tiled                           # Layout for this window (tiled, main-vertical, main-horizontal, even-vertical, even-horizontal)
-    run:                                    # List of commands to be executed in all panes
-    - ls
+    run: ls                                 # Multiline string for shell commands to be executed in this window
     panes:                                  # List of panes to be created
-    - run:
-      - nvim                                # List of commands to be executed in this pane
+    - run: nvim                                # Multiline string for shell commands to be executed in this pane
     - root: /optional/root/dir/pane         # Root directory for this pane
       active: true                          # Set as active pane
   - name: logs
     active: true                            # Set as active window
-    run:
-    - mkdir ./tmp
-    - touch ./tmp/logs.txt
-    - tail -F ./tmp/logs.txt
+    run: |
+      mkdir ./tmp
+      touch ./tmp/logs.txt
+      tail -F ./tmp/logs.txt
 ```
 
 All fields are optional unless stated as `(required)`
@@ -108,7 +105,6 @@ Destination is set but things can still change and break backwards compatibility
 - Video showcase in README
 - Opt in clearing of executed shell commands
 - Setup and destroy blocks
-- Make run parameter take in multi line string instead of array
 
 ### Post v1 ideas:
 - Migrations for template versions

--- a/internal/multiplexer/tmux_multiplexer.go
+++ b/internal/multiplexer/tmux_multiplexer.go
@@ -152,7 +152,12 @@ func (m *TmuxMultiplexer) assembleSession(sn SessionName, p project.Project) (er
 		for _, pID := range pIDs {
 			w := windows[wID]
 			p := panes[pID]
-			cmds := slices.Concat(t.Commands, w.Commands, p.Commands)
+
+			tKeys := commandToKeys(t.Commands)
+			wKeys := commandToKeys(w.Commands)
+			pKeys := commandToKeys(p.Commands)
+
+			cmds := slices.Concat(tKeys, wKeys, pKeys)
 			for _, keys := range cmds {
 				if err = m.Client.SendKeys(pID, keys); err != nil {
 					return err

--- a/internal/multiplexer/tmux_multiplexer_client.go
+++ b/internal/multiplexer/tmux_multiplexer_client.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"thop/internal/executor"
 	"thop/internal/problem"
-	"thop/internal/types/command"
 	"thop/internal/types/pane"
 	"thop/internal/types/template"
 	"thop/internal/types/window"
@@ -22,7 +21,7 @@ type TmuxClient interface {
 	NewPane(WindowID, template.Root, window.Root, pane.Pane) (PaneID, error)
 	NewSession(SessionName, template.Template) (WindowID, PaneID, error)
 	NewWindow(SessionName, template.Root, window.Window) (WindowID, PaneID, error)
-	SendKeys(PaneID, command.Command) error
+	SendKeys(PaneID, string) error
 	SetActivePane(PaneID) error
 	SetActiveWindow(WindowID) error
 	SetLayout(WindowID, window.Layout) error
@@ -161,9 +160,13 @@ func (c *TmuxClientImpl) NewWindow(sn SessionName, tr template.Root, w window.Wi
 	return WindowID(output[0]), PaneID(output[1]), nil
 }
 
-func (c *TmuxClientImpl) SendKeys(pID PaneID, keys command.Command) error {
+func (c *TmuxClientImpl) SendKeys(pID PaneID, keys string) error {
+	if keys == "" {
+		return nil // indempotent handling of empty keys
+	}
+
 	cmd := exec.Command("tmux", "send-keys", "-t", string(pID))
-	cmd.Args = append(cmd.Args, string(keys))
+	cmd.Args = append(cmd.Args, keys)
 	cmd.Args = append(cmd.Args, "C-m")
 
 	if _, _, err := c.E.Execute(cmd); err != nil {

--- a/internal/multiplexer/tmux_multiplexer_client.go
+++ b/internal/multiplexer/tmux_multiplexer_client.go
@@ -162,7 +162,7 @@ func (c *TmuxClientImpl) NewWindow(sn SessionName, tr template.Root, w window.Wi
 
 func (c *TmuxClientImpl) SendKeys(pID PaneID, keys string) error {
 	if keys == "" {
-		return nil // indempotent handling of empty keys
+		return nil // idempotent handling of empty keys
 	}
 
 	cmd := exec.Command("tmux", "send-keys", "-t", string(pID))

--- a/internal/multiplexer/tmux_utils.go
+++ b/internal/multiplexer/tmux_utils.go
@@ -2,7 +2,9 @@ package multiplexer
 
 import (
 	"os/exec"
+	"strings"
 	"thop/internal/problem"
+	"thop/internal/types/command"
 	"thop/internal/types/project"
 )
 
@@ -25,4 +27,16 @@ func resolveSessionName(p project.Project) SessionName {
 	}
 
 	return SessionName(p.Name)
+}
+
+func commandToKeys(cmd command.Command) []string {
+	var keys []string
+
+	for c := range strings.SplitSeq(string(cmd), "\n") {
+		if c != "" {
+			keys = append(keys, c)
+		}
+	}
+
+	return keys
 }

--- a/internal/types/pane/pane.go
+++ b/internal/types/pane/pane.go
@@ -5,9 +5,9 @@ import "thop/internal/types/command"
 type Root string
 
 type Pane struct {
-	Root     Root              `yaml:"root,omitempty"`
-	Commands []command.Command `yaml:"run,omitempty"`
-	Active   bool              `yaml:"active,omitempty"`
+	Root     Root            `yaml:"root,omitempty"`
+	Commands command.Command `yaml:"run,omitempty"`
+	Active   bool            `yaml:"active,omitempty"`
 }
 
 func (p *Pane) IsValid() bool {

--- a/internal/types/template/template.go
+++ b/internal/types/template/template.go
@@ -12,11 +12,11 @@ type ActiveWindow string
 type Template struct {
 	// Template name is used to specify the session name in multiplexer,
 	// if not specified, the project name should be used
-	Name         Name              `yaml:"name,omitempty"`
-	Root         Root              `yaml:"root"`
-	Commands     []command.Command `yaml:"run,omitempty"`
-	Windows      []window.Window   `yaml:"windows,omitempty"`
-	ActiveWindow ActiveWindow      `yaml:"active_window,omitempty"`
+	Name         Name            `yaml:"name,omitempty"`
+	Root         Root            `yaml:"root"`
+	Commands     command.Command `yaml:"run,omitempty"`
+	Windows      []window.Window `yaml:"windows,omitempty"`
+	ActiveWindow ActiveWindow    `yaml:"active_window,omitempty"`
 }
 
 // Will set default values for missing fields

--- a/internal/types/window/window.go
+++ b/internal/types/window/window.go
@@ -26,12 +26,12 @@ var layouts = map[string]Layout{
 }
 
 type Window struct {
-	Name     Name              `yaml:"name,omitempty"`
-	Root     Root              `yaml:"root,omitempty"`
-	Commands []command.Command `yaml:"run,omitempty"`
-	Layout   Layout            `yaml:"layout,omitempty"`
-	Panes    []pane.Pane       `yaml:"panes,omitempty"`
-	Active   bool              `yaml:"active,omitempty"`
+	Name     Name            `yaml:"name,omitempty"`
+	Root     Root            `yaml:"root,omitempty"`
+	Commands command.Command `yaml:"run,omitempty"`
+	Layout   Layout          `yaml:"layout,omitempty"`
+	Panes    []pane.Pane     `yaml:"panes,omitempty"`
+	Active   bool            `yaml:"active,omitempty"`
 }
 
 func (w *Window) WithDefaults() Window {

--- a/test/multiplexer/tmux_multiplexer_client_test.go
+++ b/test/multiplexer/tmux_multiplexer_client_test.go
@@ -362,6 +362,17 @@ func Test_TmuxClient_SendKeys(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedCmd, executor.ExecutedCommands)
 	})
+
+	t.Run("handles empty keys idempotently", func(t *testing.T) {
+		// given
+		client := multiplexer.TmuxClientImpl{}
+
+		// when
+		err := client.SendKeys("%id", "")
+
+		// then
+		assert.Nil(t, err)
+	})
 }
 
 func Test_Client_NewWindow(t *testing.T) {

--- a/test/multiplexer/tmux_multiplexer_test.go
+++ b/test/multiplexer/tmux_multiplexer_test.go
@@ -52,7 +52,7 @@ func (m *MockTmuxClient) NewWindow(
 
 func (m *MockTmuxClient) SendKeys(
 	paneID multiplexer.PaneID,
-	keys command.Command,
+	keys string,
 ) error {
 	args := m.Called(paneID, keys)
 	return args.Error(0)
@@ -113,7 +113,7 @@ func Test_AttachProject(t *testing.T) {
 			Name: "foo",
 			Template: template.Template{
 				Root:     root,
-				Commands: []command.Command{"echo hello"},
+				Commands: command.Command("echo hello"),
 				Windows: []window.Window{
 					{
 						Root:   "/project",
@@ -122,13 +122,13 @@ func Test_AttachProject(t *testing.T) {
 						Active: true,
 					},
 					{
-						Commands: []command.Command{"ls"},
+						Commands: command.Command("ls"),
 						Panes: []pane.Pane{
 							{
 								Active: true,
 							},
 							{
-								Commands: []command.Command{"echo pane"},
+								Commands: command.Command("echo pane"),
 							},
 						},
 						Layout: window.LayoutMainVertical,
@@ -145,14 +145,14 @@ func Test_AttachProject(t *testing.T) {
 
 		mockClient.On("SetLayout", w2ID, p.Template.Windows[1].Layout).Return(nil)
 
-		mockClient.On("SendKeys", p1ID, command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p1ID, "echo hello").Return(nil).Once()
 
-		mockClient.On("SendKeys", p2ID, command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", p2ID, command.Command("ls")).Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, "echo hello").Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, "ls").Return(nil).Once()
 
-		mockClient.On("SendKeys", p3ID, command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", p3ID, command.Command("ls")).Return(nil).Once()
-		mockClient.On("SendKeys", p3ID, command.Command("echo pane")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, "echo hello").Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, "ls").Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, "echo pane").Return(nil).Once()
 
 		mockClient.On("SetActiveWindow", w1ID).Return(nil).Once()
 		mockClient.On("SetActivePane", p2ID).Return(nil).Once()
@@ -180,7 +180,7 @@ func Test_AttachProject(t *testing.T) {
 			Name: "foo",
 			Template: template.Template{
 				Root:     root,
-				Commands: []command.Command{"echo hello"},
+				Commands: "echo hello",
 				Windows: []window.Window{
 					{
 						Root:   "/project",
@@ -188,11 +188,11 @@ func Test_AttachProject(t *testing.T) {
 						Layout: window.LayoutTiled,
 					},
 					{
-						Commands: []command.Command{"ls"},
+						Commands: "ls",
 						Panes: []pane.Pane{
 							{},
 							{
-								Commands: []command.Command{"echo pane"},
+								Commands: "echo pane",
 							},
 						},
 						Layout: window.LayoutTiled,
@@ -260,7 +260,7 @@ func Test_AttachProject(t *testing.T) {
 			Name: "foo",
 			Template: template.Template{
 				Root:     root,
-				Commands: []command.Command{"echo hello"},
+				Commands: "echo hello",
 				Windows: []window.Window{
 					{
 						Root:   "/project",
@@ -268,11 +268,11 @@ func Test_AttachProject(t *testing.T) {
 						Layout: window.LayoutTiled,
 					},
 					{
-						Commands: []command.Command{"ls"},
+						Commands: "ls",
 						Panes: []pane.Pane{
 							{},
 							{
-								Commands: []command.Command{"echo pane"},
+								Commands: "echo pane",
 							},
 						},
 						Layout: window.LayoutMainVertical,
@@ -289,14 +289,14 @@ func Test_AttachProject(t *testing.T) {
 
 		mockClient.On("SetLayout", w2ID, p.Template.Windows[1].Layout).Return(nil)
 
-		mockClient.On("SendKeys", p1ID, command.Command("echo hello")).Return(nil).Once()
+		mockClient.On("SendKeys", p1ID, "echo hello").Return(nil).Once()
 
-		mockClient.On("SendKeys", p2ID, command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", p2ID, command.Command("ls")).Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, "echo hello").Return(nil).Once()
+		mockClient.On("SendKeys", p2ID, "ls").Return(nil).Once()
 
-		mockClient.On("SendKeys", p3ID, command.Command("echo hello")).Return(nil).Once()
-		mockClient.On("SendKeys", p3ID, command.Command("ls")).Return(nil).Once()
-		mockClient.On("SendKeys", p3ID, command.Command("echo pane")).Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, "echo hello").Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, "ls").Return(nil).Once()
+		mockClient.On("SendKeys", p3ID, "echo pane").Return(nil).Once()
 
 		mockClient.On("SwitchSession", sn).Return(nil).Once()
 

--- a/test/types/template/template_test.go
+++ b/test/types/template/template_test.go
@@ -34,7 +34,7 @@ func Test_WithDefaults(t *testing.T) {
 					Name: "foo",
 					Panes: []pane.Pane{
 						{
-							Commands: []command.Command{"echo foo"},
+							Commands: command.Command("echo foo"),
 						},
 					},
 				},
@@ -48,7 +48,7 @@ func Test_WithDefaults(t *testing.T) {
 		temp = temp.WithDefaults()
 
 		// then
-		assert.Equal(t, pane.Pane{Commands: []command.Command{"echo foo"}}, temp.Windows[0].Panes[0])
+		assert.Equal(t, pane.Pane{Commands: command.Command("echo foo")}, temp.Windows[0].Panes[0])
 		assert.Equal(t, pane.Pane{}, temp.Windows[1].Panes[0])
 	})
 }


### PR DESCRIPTION
This PR changes the way we accepts shell commands to run, from being an array it now accepts multi line strings similar to way GHA does and other command executors configured with yaml